### PR TITLE
Handle infinite loops gracefully. Fixes #3

### DIFF
--- a/src/components/cache.js
+++ b/src/components/cache.js
@@ -1,0 +1,28 @@
+export class Cache {
+  #cache = {}
+  #hasKeys
+  #keys
+
+  constructor (keys = []) {
+    this.#keys = keys
+    this.#hasKeys = keys.length !== 0
+
+    keys.forEach((key) => { this.#cache[key] = new Cache() })
+  }
+
+  add (key, item) {
+    if (this.#hasKeys && !this.#keys.includes(key)) {
+      throw new Error(`Invalid key: ${key}`)
+    }
+
+    this.#cache[key] = item
+  }
+
+  get (key) {
+    return key ? this.#cache[key] : this.#cache
+  }
+
+  remove (key) {
+    delete this.#cache[key]
+  }
+}

--- a/src/components/collision.js
+++ b/src/components/collision.js
@@ -1,37 +1,34 @@
-import { deepEqual, uniqueBy } from './util'
+import { StepState } from './step'
 
 export class Collision {
-  constructor (points, item) {
-    this.item = item
+  constructor (index, points, items) {
+    this.index = index
+
+    // The item that was collided with
+    this.item = items[1]
+    this.itemIds = items.map((item) => item.id)
+    this.items = items
+
+    // The first collision point
     this.point = points[0]
     this.points = points
   }
 
   equals (other) {
-    return deepEqual(this, other)
+    return other && other.point.equals(this.point) &&
+      other.items.length === this.items.length &&
+      other.items.every((item) => this.has(item))
+  }
+
+  has (beam) {
+    return this.itemIds.includes(beam.id)
   }
 }
 
-export class CollisionLoop {
-  #cache
-
-  constructor (...beams) {
-    // Pull in any other beams that are involved
-    this.beams = uniqueBy(
-      beams.flatMap((beam) => {
-        const collisions = this.#cache[beam.id] = beam.getCollisions()
-        return Object.values(collisions)
-      }).map((collision) => collision.item),
-      'id'
-    )
-    this.collisions = this.beams.map((beam) => this.#cache[beam.id] ?? (this.#cache[beam.id] = beam.getCollisions()))
-  }
-
-  getCollisions (beam) {
-    return this.#cache[beam.id]
-  }
-
-  getCollisionStepIndexes (beam) {
-    return Object.keys(this.getCollisions(beam)).map(Number).sort((a, b) => a - b)
+export class CollisionMergeWith {
+  constructor (beam, step, stepIndex) {
+    this.beams = [beam].concat(step.state.get(StepState.MergeWith)?.beams || [])
+    this.colors = step.colors.concat(beam.getColors())
+    this.stepIndex = stepIndex
   }
 }

--- a/src/components/collision.js
+++ b/src/components/collision.js
@@ -1,0 +1,37 @@
+import { deepEqual, uniqueBy } from './util'
+
+export class Collision {
+  constructor (points, item) {
+    this.item = item
+    this.point = points[0]
+    this.points = points
+  }
+
+  equals (other) {
+    return deepEqual(this, other)
+  }
+}
+
+export class CollisionLoop {
+  #cache
+
+  constructor (...beams) {
+    // Pull in any other beams that are involved
+    this.beams = uniqueBy(
+      beams.flatMap((beam) => {
+        const collisions = this.#cache[beam.id] = beam.getCollisions()
+        return Object.values(collisions)
+      }).map((collision) => collision.item),
+      'id'
+    )
+    this.collisions = this.beams.map((beam) => this.#cache[beam.id] ?? (this.#cache[beam.id] = beam.getCollisions()))
+  }
+
+  getCollisions (beam) {
+    return this.#cache[beam.id]
+  }
+
+  getCollisionStepIndexes (beam) {
+    return Object.keys(this.getCollisions(beam)).map(Number).sort((a, b) => a - b)
+  }
+}

--- a/src/components/item.js
+++ b/src/components/item.js
@@ -62,7 +62,9 @@ export class Item extends Stateful {
     collisionIndex,
     collisions,
     currentStep,
+    currentStepIndex,
     nextStep,
+    nextStepIndex,
     existingNextStep,
     collisionStep
   ) {

--- a/src/components/item.js
+++ b/src/components/item.js
@@ -55,19 +55,7 @@ export class Item extends Stateful {
 
   onClick () {}
 
-  onCollision (
-    beam,
-    puzzle,
-    collision,
-    collisionIndex,
-    collisions,
-    currentStep,
-    currentStepIndex,
-    nextStep,
-    nextStepIndex,
-    existingNextStep,
-    collisionStep
-  ) {
+  onCollision ({ collisionStep }) {
     return collisionStep
   }
 

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -238,7 +238,7 @@ export class Beam extends Item {
           .filter((step) => step.state.has(StepState.Collision))
           .map((step) => step.state.get(StepState.Collision))
           .some((otherCollision) =>
-            otherCollision.item.equals(this) && fuzzyEquals(otherCollision.point, collision.point)
+            otherCollision.item?.equals(this) && fuzzyEquals(otherCollision.point, collision.point)
           )
       ) {
         console.debug(this.toString(), 're-evaluating collision with', beam.toString())
@@ -491,10 +491,9 @@ export class Beam extends Item {
     // The next step would be off the grid
     if (!tile) {
       console.debug(this.toString(), 'stopping due to out of bounds')
-      return this.updateStep(currentStepIndex, {
-        done: true,
-        state: new StepState(new StepState.Collision(currentStep.point))
-      })
+      const state = new StepState.Collision(currentStep.point)
+      this.addCollision(currentStepIndex, state.collision)
+      return this.updateStep(currentStepIndex, { done: true, state: new StepState(state) })
     }
 
     const nextStepIndex = currentStepIndex + 1
@@ -683,15 +682,15 @@ export class Beam extends Item {
 
     if (stepIndex === lastStepIndex) {
       // Update beam status if last step was updated
-      this.done = step.done
+      this.done = step?.done ?? false
     }
 
-    if (this.done && !step.state.get(StepState.Collision)) {
+    if (this.done && !step?.state.get(StepState.Collision)) {
       // If the beam ends without a collision, we can clear out any we have tracked
       this.#collisions = {}
     }
 
-    emitEvent(Beam.Events.Update, { beam: this, state: step.state, step, stepIndex })
+    emitEvent(Beam.Events.Update, { beam: this, state: step?.state, step, stepIndex })
   }
 
   #updateHistory (stepIndex) {

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -47,7 +47,6 @@ export class Beam extends Item {
     // Can't be done if adding a new step
     this.done = false
 
-    this.#path.opacity = step.projection ? 0.25 : 1
     this.#path.strokeColor = step.color
 
     if (this.path.length === 0) {
@@ -64,8 +63,7 @@ export class Beam extends Item {
       !step.connected || (
         previousStep && (
           step.color !== previousStep.color ||
-          step.insertAbove !== previousStep.insertAbove ||
-          step.projection !== previousStep.projection
+          step.insertAbove !== previousStep.insertAbove
         )
       )
     ) {
@@ -433,8 +431,7 @@ export class Beam extends Item {
       direction,
       nextStepPoint,
       existingNextStep?.pathIndex || lastPathIndex,
-      existingNextStep?.segmentIndex || lastSegmentIndex,
-      existingNextStep?.projection ?? currentStep.projection
+      existingNextStep?.segmentIndex || lastSegmentIndex
     )
 
     const items = uniqueBy(

--- a/src/components/items/filter.js
+++ b/src/components/items/filter.js
@@ -34,7 +34,7 @@ export class Filter extends movable(Item) {
     return [getColorElement(this.color)]
   }
 
-  onCollision (beam, puzzle, collision, collisionIndex, collisions, currentStep, nextStep) {
+  onCollision (beam, puzzle, collision, collisionIndex, collisions, currentStep, currentStepIndex, nextStep) {
     // The beam will collide with the filter twice, on entry and exit, so ignore the first one, but track in state
     return nextStep.copy(
       currentStep.state.has(StepState.Filter)

--- a/src/components/items/filter.js
+++ b/src/components/items/filter.js
@@ -34,7 +34,7 @@ export class Filter extends movable(Item) {
     return [getColorElement(this.color)]
   }
 
-  onCollision (beam, puzzle, collision, collisionIndex, collisions, currentStep, currentStepIndex, nextStep) {
+  onCollision (beam, puzzle, { currentStep, nextStep }) {
     // The beam will collide with the filter twice, on entry and exit, so ignore the first one, but track in state
     return nextStep.copy(
       currentStep.state.has(StepState.Filter)

--- a/src/components/items/portal.js
+++ b/src/components/items/portal.js
@@ -67,19 +67,7 @@ export class Portal extends movable(rotatable(Item)) {
 
   // TODO: allow multiple beams to enter a portal.
   // Collision should still occur between beams if one is entering and one is exiting.
-  onCollision (
-    beam,
-    puzzle,
-    collision,
-    collisionIndex,
-    collisions,
-    currentStep,
-    currentStepIndex,
-    nextStep,
-    nextStepIndex,
-    existingNextStep,
-    collisionStep
-  ) {
+  onCollision ({ beam, collisionStep, currentStep, nextStep, puzzle }) {
     const portalState = currentStep.state.get(StepState.Portal)
     if (!portalState) {
       // Handle entry collision

--- a/src/components/items/portal.js
+++ b/src/components/items/portal.js
@@ -74,7 +74,9 @@ export class Portal extends movable(rotatable(Item)) {
     collisionIndex,
     collisions,
     currentStep,
+    currentStepIndex,
     nextStep,
+    nextStepIndex,
     existingNextStep,
     collisionStep
   ) {

--- a/src/components/items/reflector.js
+++ b/src/components/items/reflector.js
@@ -42,7 +42,9 @@ export class Reflector extends movable(rotatable(Item)) {
     collisionIndex,
     collisions,
     currentStep,
+    currentStepIndex,
     nextStep,
+    nextStepIndex,
     existingNextStep,
     collisionStep
   ) {

--- a/src/components/items/reflector.js
+++ b/src/components/items/reflector.js
@@ -35,19 +35,7 @@ export class Reflector extends movable(rotatable(Item)) {
     return this.getSide(pointA) === this.getSide(pointB)
   }
 
-  onCollision (
-    beam,
-    puzzle,
-    collision,
-    collisionIndex,
-    collisions,
-    currentStep,
-    currentStepIndex,
-    nextStep,
-    nextStepIndex,
-    existingNextStep,
-    collisionStep
-  ) {
+  onCollision ({ beam, collisionStep, currentStep, nextStep }) {
     const directionFrom = getOppositeDirection(currentStep.direction)
     const directionTo = getReflectedDirection(directionFrom, this.rotation)
 
@@ -58,10 +46,11 @@ export class Reflector extends movable(rotatable(Item)) {
 
     if (directionTo === directionFrom) {
       console.debug(beam.toString(), 'stopping due to reflection back at self')
-      // Not using collisionStep here because we want to block other beams that are using the same reflector
-      return nextStep.copy({
-        done: true,
-        state: nextStep.state.copy(new StepState.Collision(nextStep.point, this))
+      // Updating the collisionStep to use nextStep.point to ensure beams using the same reflector can be collided with
+      return collisionStep.copy({
+        point: nextStep.point,
+        state: collisionStep.state.copy(
+          new StepState.Collision(collisionStep.state.get(StepState.Collision).copy({ points: [nextStep.point] })))
       })
     }
 

--- a/src/components/items/terminus.js
+++ b/src/components/items/terminus.js
@@ -66,7 +66,9 @@ export class Terminus extends movable(rotatable(toggleable(Item))) {
     collisionIndex,
     collisions,
     currentStep,
+    currentStepIndex,
     nextStep,
+    nextStepIndex,
     existingNextStep,
     collisionStep
   ) {

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -476,7 +476,7 @@ export class Puzzle {
     this.#updateBeamsCache.push(updates)
 
     // Ensure the UI has a chance to update between loops
-    setTimeout(() => this.#updateBeams(), 0)
+    setTimeout(() => this.#updateBeams(), 25)
   }
 
   #updateMessage (tile) {

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -513,6 +513,10 @@ export class Puzzle {
       this.layer.addChild(this.item.group)
     }
 
+    equals (other) {
+      return fuzzyEquals(this.point, other.point)
+    }
+
     getColor () {
       return this.beams.length
         ? chroma.average(this.beams.map((beam) => beam.getColor())).hex()
@@ -529,7 +533,7 @@ export class Puzzle {
     update () {
       // Remove any beam which no longer matches its collision point
       this.beams = this.beams.filter((beam) =>
-        beam.getCollisions().some((collision) => fuzzyEquals(collision.point, this.point)))
+        Object.values(beam.getCollisions()).some((collision) => this.equals(collision)))
 
       const color = this.getColor()
 

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -1,12 +1,8 @@
 import { Puzzles } from '../puzzles'
-import { base64decode, base64encode, jsonDiffPatch } from './util'
+import { base64decode, base64encode, jsonDiffPatch, params, url } from './util'
 
 const history = window.history
-const location = window.location
 const localStorage = window.localStorage
-
-const params = new URLSearchParams(location.search)
-const url = new URL(location)
 
 export class State {
   #current

--- a/src/components/step.js
+++ b/src/components/step.js
@@ -129,8 +129,8 @@ export class StepState {
   static CollisionLoop = class StepCollisionLoop {
     collisionLoop
 
-    constructor (collisions) {
-      this.collisionLoop = collisions
+    constructor (collisionLoop) {
+      this.collisionLoop = collisionLoop
     }
   }
 

--- a/src/components/step.js
+++ b/src/components/step.js
@@ -1,5 +1,5 @@
 import chroma from 'chroma-js'
-import { deepEqual, fuzzyEquals } from './util'
+import { deepEqual } from './util'
 
 export class Step {
   color
@@ -24,10 +24,10 @@ export class Step {
     point,
     pathIndex,
     segmentIndex,
+    projection,
     connected,
     insertAbove,
     done,
-    projection,
     state,
     onAdd,
     onRemove
@@ -64,10 +64,10 @@ export class Step {
       settings.point ?? this.point,
       settings.pathIndex ?? this.pathIndex,
       settings.segmentIndex ?? this.segmentIndex,
+      settings.projection ?? this.projection,
       settings.connected ?? this.connected,
       settings.insertAbove ?? this.insertAbove,
       settings.done ?? this.done,
-      settings.projection ?? this.projection,
       settings.state ?? new StepState(this.state),
       settings.onAdd ?? this.onAdd,
       settings.onRemove ?? this.onRemove

--- a/src/components/step.js
+++ b/src/components/step.js
@@ -1,5 +1,5 @@
 import chroma from 'chroma-js'
-import { deepEqual } from './util'
+import { deepEqual, fuzzyEquals } from './util'
 
 export class Step {
   color
@@ -12,6 +12,7 @@ export class Step {
   onRemove
   point
   pathIndex
+  projection
   segmentIndex
   state
   tile
@@ -26,6 +27,7 @@ export class Step {
     connected,
     insertAbove,
     done,
+    projection,
     state,
     onAdd,
     onRemove
@@ -48,6 +50,7 @@ export class Step {
     this.onRemove = onRemove
     this.point = point
     this.pathIndex = pathIndex
+    this.projection = projection ?? false
     this.segmentIndex = segmentIndex
     this.state = state ?? new StepState()
     this.tile = tile
@@ -64,6 +67,7 @@ export class Step {
       settings.connected ?? this.connected,
       settings.insertAbove ?? this.insertAbove,
       settings.done ?? this.done,
+      settings.projection ?? this.projection,
       settings.state ?? new StepState(this.state),
       settings.onAdd ?? this.onAdd,
       settings.onRemove ?? this.onRemove
@@ -120,6 +124,14 @@ export class StepState {
 
   static Filter = class StepFilter {
     filter = {}
+  }
+
+  static CollisionLoop = class StepCollisionLoop {
+    collisionLoop
+
+    constructor (collisions) {
+      this.collisionLoop = collisions
+    }
   }
 
   static MergeInto = class StepMergeInto {

--- a/src/components/step.js
+++ b/src/components/step.js
@@ -12,7 +12,6 @@ export class Step {
   onRemove
   point
   pathIndex
-  projection
   segmentIndex
   state
   tile
@@ -25,7 +24,6 @@ export class Step {
     point,
     pathIndex,
     segmentIndex,
-    projection,
     connected,
     insertAbove,
     done,
@@ -53,7 +51,6 @@ export class Step {
     this.onRemove = onRemove ?? (() => {})
     this.point = point
     this.pathIndex = pathIndex
-    this.projection = projection ?? false
     this.segmentIndex = segmentIndex
     this.state = state ?? new StepState()
     this.tile = tile
@@ -68,7 +65,6 @@ export class Step {
       settings.point ?? this.point,
       settings.pathIndex ?? this.pathIndex,
       settings.segmentIndex ?? this.segmentIndex,
-      settings.projection ?? this.projection,
       settings.connected ?? this.connected,
       settings.insertAbove ?? this.insertAbove,
       settings.done ?? this.done,

--- a/src/components/util.js
+++ b/src/components/util.js
@@ -211,5 +211,3 @@ export function uniqueBy (array, key) {
   const values = array.map((value) => value[key])
   return array.filter((value, index) => !values.includes(value[key], index + 1))
 }
-
-//window.uniqueBy = uniqueBy

--- a/src/components/util.js
+++ b/src/components/util.js
@@ -2,6 +2,11 @@ import * as jsonDiffPatchFactory from 'jsondiffpatch'
 import pako from 'pako'
 import chroma from 'chroma-js'
 
+const location = window.location
+
+export const params = new URLSearchParams(location.search)
+export const url = new URL(location)
+
 // noinspection JSCheckFunctionSignatures
 export const jsonDiffPatch = jsonDiffPatchFactory.create({ objectHash: deepEqual })
 
@@ -23,14 +28,6 @@ export function addDegrees (original, degrees) {
 
 export function addDirection (direction, amount) {
   return ((direction + amount) + 6) % 6
-}
-
-export function capitalize (string) {
-  return string.charAt(0).toUpperCase() + string.slice(1)
-}
-
-export function coalesce (...args) {
-  return args.findLast((arg) => arg !== undefined)
 }
 
 export function base64decode (string) {
@@ -55,6 +52,14 @@ function base64escape (string) {
 function base64unescape (string) {
   return (string + '==='.slice((string.length + 3) % 4))
     .replace(/-/g, '+').replace(/_/g, '/')
+}
+
+export function capitalize (string) {
+  return string.charAt(0).toUpperCase() + string.slice(1)
+}
+
+export function coalesce (...args) {
+  return args.findLast((arg) => arg !== undefined)
 }
 
 /**

--- a/src/components/util.js
+++ b/src/components/util.js
@@ -206,3 +206,10 @@ export function removeClass (className, ...elements) {
 export function subtractDirection (direction, amount) {
   return addDirection(direction, amount * -1)
 }
+
+export function uniqueBy (array, key) {
+  const values = array.map((value) => value[key])
+  return array.filter((value, index) => !values.includes(value[key], index + 1))
+}
+
+//window.uniqueBy = uniqueBy

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,19 @@
 import paper, { Point, Size } from 'paper'
 import { Puzzle } from './components/puzzle'
-import { addClass, debounce, removeClass } from './components/util'
+import { addClass, debounce, params, removeClass } from './components/util'
 import { Puzzles } from './puzzles'
 import { OffsetCoordinates } from './components/coordinates/offset'
+
+const beaming = window.beaming = {}
+const console = window.console = window.console || { debug: function () {} }
+
+const consoleDebug = console.debug
+beaming.debug = function (debug) {
+  console.debug = debug ? consoleDebug : function () {}
+}
+
+// Silence debug logging by default since it can affect performance
+beaming.debug(params.has('debug') ?? false)
 
 const elements = Object.freeze({
   dialog: document.getElementById('dialog'),
@@ -19,7 +30,7 @@ const elements = Object.freeze({
   undo: document.getElementById('undo')
 })
 
-const puzzle = new Puzzle(elements.puzzle)
+const puzzle = beaming.puzzle = new Puzzle(elements.puzzle)
 
 elements.info.addEventListener('click', () => {
   if (!elements.dialog.open) {
@@ -130,13 +141,12 @@ document.body.addEventListener('contextmenu', (event) => {
 // Initialize
 puzzle.select()
 
-// Expose for debug purposes
-const beaming = window.beaming = { paper, puzzle }
-
+// Used by functional tests
 beaming.centerOnTile = function (r, c) {
   return puzzle.centerOnTile(new OffsetCoordinates(r, c))
 }
 
+// Useful for debug purposes
 beaming.drawDebugPoint = function (x, y, style) {
   return puzzle.drawDebugPoint(new Point(x, y), style)
 }

--- a/src/puzzles/index.js
+++ b/src/puzzles/index.js
@@ -14,6 +14,7 @@ import _010 from './010'
 import testLayout from './testLayout'
 import testPortal from './testPortal'
 import testReflector from './testReflector'
+import testInfiniteLoop from './testInfiniteLoop'
 
 // Ensure puzzle configuration is valid JSON
 const configuration = Object.fromEntries(Object.entries({
@@ -27,6 +28,7 @@ const configuration = Object.fromEntries(Object.entries({
   '008': _008,
   '009': _009,
   '010': _010,
+  test_infinite_loop: testInfiniteLoop,
   test_layout: testLayout,
   test_portal: testPortal,
   test_reflector: testReflector

--- a/src/puzzles/testInfiniteLoop.js
+++ b/src/puzzles/testInfiniteLoop.js
@@ -1,0 +1,85 @@
+export default {
+  layout: {
+    tiles: [
+      [
+        {
+          items: [
+            {
+              color: 'red',
+              openings: [null, null, null, { on: true, type: 'Beam' }, null, null],
+              type: 'Terminus'
+            }
+          ],
+          type: 'Tile'
+        },
+        {
+          items: [
+            {
+              rotation: 2,
+              type: 'Reflector'
+            }
+          ],
+          type: 'Tile'
+        },
+        {
+          type: 'Tile'
+        },
+        {
+          items: [
+            {
+              color: 'red',
+              openings: [null, null, null, null, null, { on: true, type: 'Beam' }],
+              type: 'Terminus'
+            }
+          ],
+          type: 'Tile'
+        }
+      ],
+      [
+        {
+          type: 'Tile'
+        },
+        {
+          type: 'Tile'
+        },
+        {
+          type: 'Tile'
+        }
+      ],
+      [
+        null,
+        {
+          items: [
+            {
+              rotation: 4,
+              type: 'Reflector'
+            }
+          ],
+          type: 'Tile'
+        },
+        {
+          items: [
+            {
+              rotation: 2,
+              type: 'Reflector'
+            }
+          ],
+          type: 'Tile'
+        },
+        {
+          items: [
+            {
+              color: 'blue',
+              openings: [{ on: true, type: 'Beam' }, null, null, null, null, null],
+              type: 'Terminus'
+            }
+          ],
+          type: 'Tile'
+        }
+      ]
+    ]
+  },
+  solution: [
+    { amount: 100, type: 'Connections' }
+  ]
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -304,12 +304,12 @@ main {
   flex: 0;
 }
 
-.puzzle-error #puzzle,
+.puzzle-error:not(.puzzle-loaded) #puzzle,
 .puzzle-error .modifiers {
   display: none;
 }
 
-.puzzle-error #error {
+.puzzle-error:not(.puzzle-loaded) #error {
   display: flex;
 }
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,6 +1,6 @@
 require('chromedriver')
 const chrome = require('selenium-webdriver/chrome')
-const { Builder, By, until } = require('selenium-webdriver')
+const { Builder, By, until, WebElementCondition } = require('selenium-webdriver')
 
 class PuzzleFixture {
   driver
@@ -58,7 +58,7 @@ class PuzzleFixture {
   }
 
   async isSolved () {
-    return hasClass(this.elements.body, 'puzzle-solved')
+    return elementHasClass(this.elements.body, 'puzzle-solved')
   }
 
   async selectModifier (name) {
@@ -74,9 +74,10 @@ class PuzzleFixture {
   static baseUrl = 'http://localhost:1234'
 }
 
-async function hasClass (element, name) {
-  const classes = (await element.getAttribute('class')).split(' ')
-  return classes.some((className) => name === className)
+function elementHasClass (element, name) {
+  return new WebElementCondition('until element has class', function () {
+    return element.getAttribute('class').then((classes) => classes.split(' ').some((className) => name === className))
+  })
 }
 
 module.exports = {


### PR DESCRIPTION
The primary change that addresses the issue in #3 is that the beam update loop now happens asynchronously via `setTimeout` -- this allows the UI to update in between loops. Previously, it looped forever and the UI (and browser) would become unresponsive. The UI will now correctly show the beams colliding and updating as the infinite loop occurs, and the UI can still be interacted with, allowing users to make a move to break out of the loop.

This PR also contains a lot of other cleanup that was done as part of a larger refactoring which was eventually removed in favor of this simpler fix.