### PR TITLE
Conditionally load third party scripts

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,5 +17,7 @@ jobs:
         run: npm install
       - name: Run server
         run: npm start &
+        env:
+          NODE_ENV: ci
       - name: Run tests
         run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
         run: npm install
       - name: Run server
         run: npm start &
+        env:
+          NODE_ENV: ci
       - name: Run tests
         run: npm test
       - name: Build NPM package

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,8 @@
+const script = document.createElement('script')
+script.setAttribute('src', 'https://www.googletagmanager.com/gtag/js?id=G-HXLD6EE5NS')
+document.head.append(script)
+
+window.dataLayer = window.dataLayer || [];
+function gtag () {dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', 'G-HXLD6EE5NS');

--- a/src/components/infoDialog.js
+++ b/src/components/infoDialog.js
@@ -1,6 +1,0 @@
-const dialog = document.getElementById('dialog')
-document.getElementById('info').addEventListener('click', () => {
-  if (!dialog.open) {
-    dialog.showModal()
-  }
-})

--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,0 +1,17 @@
+const doorbellOptions = window.doorbellOptions = {
+  appKey: "o1smdnJiyxObjMcY0jSTf08TIhA814yLq68rEwTDWTavma7dtIVKEdwzMePE2LHC",
+  container: document.getElementById('feedback-container'),
+  hideButton: true,
+  properties: {}
+}
+
+const script = document.createElement('script')
+script.setAttribute(
+  'src',
+  'https://embed.doorbell.io/button/14129/1705777677/init?native_json=1&needs_postmessage=0'
+)
+document.head.append(script)
+
+document.addEventListener('puzzle-updated', (event) => {
+  doorbellOptions.properties.puzzleId = event.detail.state.getId()
+})

--- a/src/index.html
+++ b/src/index.html
@@ -3,19 +3,10 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, user-scalable=no" />
-    <meta name="description" content="A free, browser-based puzzle game." />
+    <meta name="description" content="A free, browser-based puzzle game that involves directing beams through a hexagonal grid." />
     <meta name="robots" content="index, follow" />
 
     <title>Beaming</title>
-
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HXLD6EE5NS"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-HXLD6EE5NS');
-    </script>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -210,15 +201,5 @@
       </div>
     </footer>
   </body>
-  <script defer src="https://embed.doorbell.io/button/14129/1705777677/init?native_json=1&needs_postmessage=0"></script>
-  <script>
-    window.doorbell ??= {};
-    window.doorbellOptions = {
-      appKey: "o1smdnJiyxObjMcY0jSTf08TIhA814yLq68rEwTDWTavma7dtIVKEdwzMePE2LHC",
-      container: document.getElementById('feedback-container'),
-      hideButton: true,
-      properties: {}
-    };
-  </script>
   <script type="module" src="index.js"></script>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
-import './components/feedback'
-import './components/infoDialog'
+import './info'
 import { debug } from './components/debug'
 import { Point } from 'paper'
 import { Puzzle } from './components/puzzle'
 import { OffsetCoordinates } from './components/coordinates/offset'
+
+if (process.env.NODE_ENV !== 'ci') {
+  require('./analytics')
+  require('./feedback')
+}
 
 const puzzle = new Puzzle()
 const beaming = { debug, puzzle }

--- a/src/info.js
+++ b/src/info.js
@@ -1,14 +1,14 @@
-import { Puzzle } from './puzzle'
-
 const container = document.getElementById('feedback-container')
+const dialog = document.getElementById('dialog')
 const help = document.getElementById('help')
+
+document.getElementById('info').addEventListener('click', () => {
+  if (!dialog.open) {
+    dialog.showModal()
+  }
+})
 
 document.getElementById('feedback').addEventListener('click', () => {
   help.setAttribute('open', 'true')
   container.scrollIntoView(true)
-})
-
-const doorbellOptions = window.doorbellOptions
-document.addEventListener(Puzzle.Events.Updated, (event) => {
-  doorbellOptions.properties.puzzleId = event.detail.state.getId()
 })


### PR DESCRIPTION
In an attempt to speed up functional tests, only load analytics and feedback scripts outside of continuous integration.

This relates to #10 