### PR TITLE
Add visual indication for tiles with modifiers

### DIFF
--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -6,7 +6,7 @@ import {
   emitEvent,
   fuzzyEquals,
   getConvertedDirection,
-  getMidPoint,
+  getPointBetween,
   getDistance,
   getOppositeDirection,
   uniqueBy
@@ -406,7 +406,7 @@ export class Beam extends Item {
 
     // Use the midpoint between the previous and next step points to calculate which tile we are in.
     // This will ensure we consistently pick the same tile when the next step point is on the edge of two tiles.
-    const tile = puzzle.getTile(getMidPoint(currentStep.point, nextStepPoint))
+    const tile = puzzle.getTile(getPointBetween(currentStep.point, nextStepPoint))
 
     // The next step would be off the grid
     if (!tile) {

--- a/src/components/items/reflector.js
+++ b/src/components/items/reflector.js
@@ -1,7 +1,7 @@
 import { Path, Point, Size } from 'paper'
 import { Item } from '../item'
 import { rotatable } from '../modifiers/rotate'
-import { getMidPoint, getOppositeDirection, getPosition, getReflectedDirection } from '../util'
+import { getPointBetween, getOppositeDirection, getPosition, getReflectedDirection } from '../util'
 import { Beam } from './beam'
 import { movable } from '../modifiers/move'
 import { StepState } from '../step'
@@ -22,8 +22,8 @@ export class Reflector extends movable(rotatable(Item)) {
   midLine () {
     // Two points which form a line through the mid-point of the reflector
     return [
-      getMidPoint(this.#item.segments[3].point, this.#item.segments[0].point),
-      getMidPoint(this.#item.segments[1].point, this.#item.segments[2].point)
+      getPointBetween(this.#item.segments[3].point, this.#item.segments[0].point),
+      getPointBetween(this.#item.segments[1].point, this.#item.segments[2].point)
     ]
   }
 

--- a/src/components/util.js
+++ b/src/components/util.js
@@ -154,9 +154,9 @@ export function getIconElement (name, title) {
   return span
 }
 
-export function getMidPoint (pointA, pointB) {
+export function getPointBetween (pointA, pointB, length = (length) => length / 2) {
   const vector = pointA.subtract(pointB)
-  vector.length = vector.length / 2
+  vector.length = typeof length === 'function' ? length(vector.length) : length
   return pointA.subtract(vector)
 }
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -33,7 +33,10 @@ class PuzzleFixture {
       '--window-size=768,1024'
     )
 
+    console.log('Building driver...')
     this.driver = await new Builder().forBrowser('chrome').setChromeOptions(options).build()
+
+    console.log(`Getting URL: ${this.url}`)
     await this.driver.get(this.url)
 
     this.elements.body = await this.driver.findElement(By.tagName('body'))


### PR DESCRIPTION
This will prevent users from having to click around on tiles to see if
the tile has any modifiers applied to it. This can become especially
problematic on large puzzles.