### PR TITLE
Fix bug in cache get method. Fixes #14

### DIFF
--- a/src/components/cache.js
+++ b/src/components/cache.js
@@ -19,7 +19,7 @@ export class Cache {
   }
 
   get (key) {
-    return key ? this.#cache[key] : this.#cache
+    return key === undefined ? this.#cache : this.#cache[key]
   }
 
   keys (key) {


### PR DESCRIPTION
This was failing when the key was `0`, for example.