### PR TITLE
Add puzzle 012

### DIFF
--- a/src/components/item.js
+++ b/src/components/item.js
@@ -16,7 +16,12 @@ export class Item extends Stateful {
   constructor (parent, state, configuration) {
     super(state)
 
-    this.type = state?.type || configuration?.type
+    this.type = state?.type ?? configuration?.type
+    if (this.type === undefined) {
+      console.debug(`[Item:${this.id}]`, state)
+      throw new Error('Item must have type defined')
+    }
+
     this.data = Object.assign({ id: this.id, type: this.type }, configuration?.data || {})
     this.locked = configuration?.locked !== false
 

--- a/src/components/item.js
+++ b/src/components/item.js
@@ -6,7 +6,8 @@ export class Item extends Stateful {
   center
   data
   group
-  id = Item.uniqueId++
+  id
+  immutable
   // Whether the item can be clicked on
   locked
   parent
@@ -14,8 +15,13 @@ export class Item extends Stateful {
   type
 
   constructor (parent, state, configuration) {
+    // Retain ID from state if it exists, otherwise generate a new one
+    state.id ??= Item.uniqueId++
+
     super(state)
 
+    this.id = state.id
+    this.immutable ??= state?.immutable ?? false
     this.type = state?.type ?? configuration?.type
     if (this.type === undefined) {
       console.debug(`[Item:${this.id}]`, state)
@@ -79,6 +85,10 @@ export class Item extends Stateful {
   }
 
   update () {}
+
+  static immutable (item) {
+    return item.immutable
+  }
 
   static Types = Object.freeze(Object.fromEntries([
     'beam',

--- a/src/components/itemFactory.js
+++ b/src/components/itemFactory.js
@@ -5,28 +5,28 @@ import { Reflector } from './items/reflector'
 import { Wall } from './items/wall'
 import { Item } from './item'
 
-export function itemFactory (parent, configuration) {
+export function itemFactory (parent, state, configuration) {
   let item
 
-  switch (configuration.type) {
+  switch (state.type) {
     case Item.Types.filter:
-      item = new Filter(parent, configuration)
+      item = new Filter(...arguments)
       break
     case Item.Types.portal:
-      item = new Portal(parent, configuration)
+      item = new Portal(...arguments)
       break
     case Item.Types.terminus:
-      item = new Terminus(parent, configuration)
+      item = new Terminus(...arguments)
       break
     case Item.Types.reflector:
-      item = new Reflector(parent, configuration)
+      item = new Reflector(...arguments)
       break
     case Item.Types.wall:
-      item = new Wall(parent, configuration)
+      item = new Wall(...arguments)
       break
     default:
-      console.error('Ignoring item with unknown type:', configuration.type)
-      break
+      console.debug('itemFactory', state)
+      throw new Error(`Cannot create item with unknown type: ${state.type}`)
   }
 
   if (item) {

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -556,6 +556,8 @@ export class Beam extends Item {
   updateStep (stepIndex, settings) {
     const step = this.getStep(stepIndex)
     if (step) {
+      // Update is essentially: remove, update, add
+      step.onRemove()
       const updatedStep = this.#getUpdatedStep(step, settings)
       this.#steps[stepIndex] = updatedStep
       updatedStep.onAdd(updatedStep)

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -128,7 +128,7 @@ export class Beam extends Item {
   getColorElements (tile) {
     // Show color elements for merged beams
     const step = this.getSteps(tile).find((step) => step.state.has(StepState.MergeWith))
-    return step ? getColorElements(step.color) : []
+    return step ? getColorElements(step.colors) : []
   }
 
   getCompoundPath () {
@@ -287,16 +287,14 @@ export class Beam extends Item {
       }
     }
 
-    const isSameDirection = step.direction === nextStep.direction
-    if (currentStep.state.get(StepState.Portal)?.exitPortal && !isSameDirection) {
-      console.debug(
-        this.toString(),
-        'ignoring collision with beam using same portal with different exit direction',
-        beam.toString()
-      )
+    // Check for a portal on either beam
+    const portal = currentStep.state.get(StepState.Portal) ?? step.state.get(StepState.Portal)
+    if (portal) {
+      console.debug(this.toString(), 'ignoring collision with beam using same portal', beam.toString())
       return
     }
 
+    const isSameDirection = step.direction === nextStep.direction
     if (!isSameDirection || isSelf) {
       // Beams are traveling in different directions (collision), or a beam is trying to merge into itself
       console.debug(beam.toString(), 'has collided with', (isSelf ? 'self' : this.toString()), collision)

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -26,6 +26,9 @@ export class Beam extends Item {
   #steps = []
 
   constructor (terminus, state, configuration) {
+    // Exclude from modification
+    state.immutable = true
+
     super(...arguments)
 
     this.group = null
@@ -348,8 +351,6 @@ export class Beam extends Item {
     if (!this.isOn()) {
       if (this.#steps.length) {
         console.debug(this.toString(), 'beam has been toggled off')
-        // Delete any steps-related state. No delta necessary for this as it will be covered by toggle.
-        this.updateState((state) => { state.steps = {} }, false)
         this.remove()
       }
       return

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -348,6 +348,8 @@ export class Beam extends Item {
     if (!this.isOn()) {
       if (this.#steps.length) {
         console.debug(this.toString(), 'beam has been toggled off')
+        // Delete any steps-related state. No delta necessary for this as it will be covered by toggle.
+        this.updateState((state) => { state.steps = {} }, false)
         this.remove()
       }
       return
@@ -557,7 +559,7 @@ export class Beam extends Item {
     const step = this.getStep(stepIndex)
     if (step) {
       // Update is essentially: remove, update, add
-      step.onRemove()
+      step.onRemove(step)
       const updatedStep = this.#getUpdatedStep(step, settings)
       this.#steps[stepIndex] = updatedStep
       updatedStep.onAdd(updatedStep)

--- a/src/components/items/beam.js
+++ b/src/components/items/beam.js
@@ -348,8 +348,6 @@ export class Beam extends Item {
     if (!this.isOn()) {
       if (this.#steps.length) {
         console.debug(this.toString(), 'beam has been toggled off')
-        // Also reset any state changes from user move decisions
-        this.updateState((state) => { delete state.moves })
         this.remove()
       }
       return

--- a/src/components/items/terminus.js
+++ b/src/components/items/terminus.js
@@ -22,15 +22,15 @@ export class Terminus extends movable(rotatable(toggleable(Item))) {
       colors.length ? colors : (Array.isArray(state.color) ? state.color : [state.color])
     ).hex()
 
-    const openings = state.openings.map((state, direction) =>
-      state
+    const openings = state.openings.map((opening, direction) =>
+      opening
         ? new Terminus.#Opening(
-          state.color || color,
+          opening.color ?? color,
           direction,
-          state.connected,
-          state.on
+          opening.connected,
+          opening.on ?? state.on
         )
-        : state
+        : opening
     ).filter((opening) => opening)
 
     this.#ui = Terminus.ui(tile, color, openings)

--- a/src/components/items/tile.js
+++ b/src/components/items/tile.js
@@ -124,7 +124,8 @@ export class Tile extends Item {
 
   update () {
     super.update()
-    this.#ui.indicator.opacity = this.modifiers.length ? 1 : 0
+    // Display the indicator if the tile contains non-immutable modifiers
+    this.#ui.indicator.opacity = this.modifiers.filter((modifier) => !modifier.immutable).length ? 1 : 0
   }
 
   static parameters (height) {

--- a/src/components/items/wall.js
+++ b/src/components/items/wall.js
@@ -8,7 +8,11 @@ export class Wall extends movable(rotatable(Item)) {
   sortOrder = 1
 
   constructor (tile, state) {
+    // Exclude from modification by default
+    state.immutable ??= true
+
     super(tile, state, { rotationDegrees: 60 })
+
     const walls = Wall.item(tile, state)
     this.group.addChildren(walls)
   }

--- a/src/components/modifier.js
+++ b/src/components/modifier.js
@@ -3,6 +3,7 @@ import { Puzzle } from './puzzle'
 import { Stateful } from './stateful'
 import { EventListeners } from './eventListeners'
 import { Interact } from './interact'
+import { Item } from './item'
 
 const modifiersImmutable = document.getElementById('modifiers-immutable')
 const modifiersMutable = document.getElementById('modifiers-mutable')
@@ -99,8 +100,10 @@ export class Modifier extends Stateful {
   }
 
   moveFilter (tile) {
-    // Filter out immutable tiles
-    return tile.modifiers.some((modifier) => modifier.type === Modifier.Types.immutable)
+    // Mask immutable tiles
+    return tile.modifiers.some(Modifier.immutable) ||
+      // Mask tiles that only contain immutable items
+      tile.items.every(Item.immutable)
   }
 
   onDeselected () {
@@ -115,10 +118,8 @@ export class Modifier extends Stateful {
       this.onToggle(event)
     } else {
       this.#down = true
-      if (
-        !this.#mask &&
-        !this.tile.modifiers.some((modifier) => [Modifier.Types.immutable, Modifier.Types.lock].includes(modifier.type))
-      ) {
+      if (!this.#mask && !this.tile.modifiers.some(Modifier.immovable)) {
+        // No active mask and modifiers are not immovable
         this.#timeoutId = setTimeout(this.onSelected.bind(this), this.#selectionTime)
       }
     }
@@ -233,6 +234,10 @@ export class Modifier extends Stateful {
     }
   }
 
+  static immovable (modifier) {
+    return Modifier.immovableTypes.includes(modifier.type)
+  }
+
   static immutable (modifier) {
     return modifier.type === Modifier.Types.immutable
   }
@@ -251,4 +256,6 @@ export class Modifier extends Stateful {
     'swap',
     'toggle'
   ].map((type) => [type, capitalize(type)])))
+
+  static immovableTypes = [Modifier.Types.immutable, Modifier.Types.lock]
 }

--- a/src/components/modifiers/move.js
+++ b/src/components/modifiers/move.js
@@ -45,9 +45,13 @@ export class Move extends Modifier {
   }
 
   tileFilter (tile) {
-    // Filter out immutable tiles and tiles with items, except for the current tile
-    return tile.modifiers.some(Modifier.immutable) ||
-      (tile.items.filter((item) => item.type !== Item.Types.beam).length > 0 && !(tile === this.tile))
+    // Never mask current tile
+    return !tile.equals(this.tile) && (
+      // Mask immutable tiles
+      tile.modifiers.some(Modifier.immutable) ||
+      // Mask tiles that contain any items we don't ignore
+      tile.items.some((item) => !Move.ignoreItemTypes.includes(item.type))
+    )
   }
 
   #maskOnTap (puzzle, tile) {
@@ -73,6 +77,8 @@ export class Move extends Modifier {
   static movable (item) {
     return item.movable
   }
+
+  static ignoreItemTypes = [Item.Types.beam, Item.Types.wall]
 }
 
 /**

--- a/src/components/modifiers/move.js
+++ b/src/components/modifiers/move.js
@@ -32,7 +32,7 @@ export class Move extends Modifier {
 
   moveFilter (tile) {
     // Filter out tiles that contain no movable items
-    return super.moveFilter(tile) || !tile.items.some((item) => item.movable)
+    return super.moveFilter(tile) || !tile.items.some(Move.movable)
   }
 
   moveItems (tile) {
@@ -89,10 +89,9 @@ export class Move extends Modifier {
 export const movable = (SuperClass) => class MovableItem extends SuperClass {
   movable
 
-  constructor (parent, configuration) {
+  constructor (parent, state) {
     super(...arguments)
-
-    this.movable = configuration.movable !== false
+    this.movable = !this.immutable && state.movable !== false
   }
 
   move (tile) {

--- a/src/components/modifiers/rotate.js
+++ b/src/components/modifiers/rotate.js
@@ -51,7 +51,7 @@ export const rotatable = (SuperClass) => class RotatableItem extends SuperClass 
     super(...arguments)
 
     this.direction = coalesce(state.direction, configuration.direction)
-    this.rotatable = coalesce(true, state.rotatable, configuration.rotatable)
+    this.rotatable = !this.immutable && coalesce(true, state.rotatable, configuration.rotatable)
     this.rotationDegrees = coalesce(60, state.rotationDegrees, configuration.rotationDegrees)
     this.rotation = coalesce(0, state.rotation, configuration.rotation) % this.getMaxRotation()
   }
@@ -80,12 +80,14 @@ export const rotatable = (SuperClass) => class RotatableItem extends SuperClass 
   }
 
   rotateGroup (rotation) {
-    if (this.rotatable) {
-      this.group.rotate(rotation * this.rotationDegrees, this.center)
-    }
+    this.group.rotate(rotation * this.rotationDegrees, this.center)
   }
 
   rotate (clockwise) {
+    if (!this.rotatable) {
+      return
+    }
+
     const rotation = clockwise === false ? -1 : 1
 
     this.rotation = (rotation + this.rotation) % this.getMaxRotation()

--- a/src/components/modifiers/swap.js
+++ b/src/components/modifiers/swap.js
@@ -1,6 +1,5 @@
 import { Move } from './move'
 import { Modifier } from '../modifier'
-import { Item } from '../item'
 
 export class Swap extends Move {
   name = 'swap_horiz'
@@ -20,7 +19,12 @@ export class Swap extends Move {
   }
 
   tileFilter (tile) {
-    // Filter out immutable tiles and tiles without items
-    return tile.modifiers.some(Modifier.immutable) || !tile.items.filter((item) => item.type !== Item.Types.beam).length
+    // Never mask current tile
+    return !tile.equals(this.tile) && (
+      // Mask immutable tiles
+      tile.modifiers.some(Modifier.immutable) ||
+      // Mask tiles that don't contain any movable items
+      !tile.items.some(Move.movable)
+    )
   }
 }

--- a/src/components/modifiers/toggle.js
+++ b/src/components/modifiers/toggle.js
@@ -54,7 +54,7 @@ export const toggleable = (SuperClass) => class ToggleableItem extends SuperClas
   constructor (parent, configuration) {
     super(...arguments)
 
-    this.toggleable = configuration.toggleable !== false
+    this.toggleable = !this.immutable && configuration.toggleable !== false
   }
 
   onToggle () {}

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -393,8 +393,9 @@ export class Puzzle {
   }
 
   #redo () {
-    this.#state.redo()
-    this.#reload()
+    if (this.#state.redo()) {
+      this.#reload()
+    }
   }
 
   #reload () {
@@ -415,8 +416,9 @@ export class Puzzle {
   }
 
   #reset () {
-    this.#state.reset()
-    this.#reload()
+    if (this.#state.reset()) {
+      this.#reload()
+    }
   }
 
   #resize () {
@@ -471,12 +473,14 @@ export class Puzzle {
     this.#collisions = {}
     this.#isUpdatingBeams = false
     this.#mask = undefined
+    this.#maskQueue = []
     this.#termini = []
   }
 
   #undo () {
-    this.#state.undo()
-    this.#reload()
+    if (this.#state.undo()) {
+      this.#reload()
+    }
   }
 
   #updateActions () {
@@ -496,6 +500,10 @@ export class Puzzle {
 
     if (!this.#state.canRedo()) {
       disable.push(elements.redo)
+    }
+
+    if (!this.#state.canReset()) {
+      disable.push(elements.reset)
     }
 
     if (!Puzzles.visible.has(id)) {

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -134,6 +134,7 @@ export class Puzzle {
         throw new Error(`Duplicate mask detected: ${mask.id}`)
       }
 
+      console.debug('adding mask to queue', mask)
       this.#maskQueue.push(mask)
       return
     }
@@ -176,6 +177,7 @@ export class Puzzle {
   }
 
   unmask () {
+    console.debug('unmask', this.#mask)
     this.layers.mask.removeChildren()
     this.#updateMessage(this.selectedTile)
     this.#mask.onUnmask(this)
@@ -185,6 +187,7 @@ export class Puzzle {
 
     const mask = this.#maskQueue.pop()
     if (mask) {
+      console.debug('processing next mask in queue', mask)
       // Evaluate after any current events have processed (e.g. beam updates from last mask)
       setTimeout(() => this.mask(mask), 0)
     }
@@ -215,10 +218,12 @@ export class Puzzle {
     return previouslySelectedTile
   }
 
-  updateState () {
-    this.#state.update(Object.assign(this.#state.getCurrent(), { layout: this.layout.getState() }))
+  updateState (keepDelta = true) {
+    this.#state.update(Object.assign(this.#state.getCurrent(), { layout: this.layout.getState() }), keepDelta)
     this.#updateActions()
-    emitEvent(Puzzle.Events.Updated, { state: this.#state })
+    if (keepDelta) {
+      emitEvent(Puzzle.Events.Updated, { state: this.#state })
+    }
   }
 
   #addLayers () {
@@ -439,8 +444,8 @@ export class Puzzle {
       : undefined
 
     this.updateSelectedTile(selectedTile)
+    this.updateState(false)
     this.update()
-    this.#updateActions()
   }
 
   #teardown () {

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -189,7 +189,13 @@ export class Puzzle {
     if (mask) {
       console.debug('processing next mask in queue', mask)
       // Evaluate after any current events have processed (e.g. beam updates from last mask)
-      setTimeout(() => this.mask(mask), 0)
+      setTimeout(() => {
+        // Allow mask to update since state may have changed since it was queued
+        // If onUpdate returns false the mask will not be applied
+        if (mask.onUpdate() !== false) {
+          this.mask(mask)
+        }
+      })
     }
   }
 
@@ -637,6 +643,7 @@ export class Puzzle {
       this.onMask = configuration.onMask ?? noop
       this.onTap = configuration.onTap ?? noop
       this.onUnmask = configuration.onUnmask ?? noop
+      this.onUpdate = configuration.onUpdate ?? noop
     }
 
     equals (other) {

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -120,7 +120,7 @@ export class State {
     }
   }
 
-  update (newState) {
+  update (newState, keepDelta = true) {
     const delta = jsonDiffPatch.diff(this.#current, newState)
     console.debug('delta', delta)
 
@@ -130,17 +130,20 @@ export class State {
     }
 
     // Handle updating after undoing
-    if (this.#index < this.#lastIndex()) {
+    if (keepDelta && this.#index < this.#lastIndex()) {
       // Remove all deltas after the current one
       this.#deltas.splice(this.#index + 1)
     }
 
     this.apply(delta)
 
-    // It seems that the jsondiffpatch library modifies deltas on patch. To prevent that, they will be stored as
-    // their stringified JSON representation and parsed before being applied.
-    // See:https://github.com/benjamine/jsondiffpatch/issues/34
-    this.#deltas.push(JSON.stringify(delta))
+    if (keepDelta) {
+      // It seems that the jsondiffpatch library modifies deltas on patch. To prevent that, they will be stored as
+      // their stringified JSON representation and parsed before being applied.
+      // See:https://github.com/benjamine/jsondiffpatch/issues/34
+      this.#deltas.push(JSON.stringify(delta))
+    }
+
     this.#index = this.#lastIndex()
 
     this.#updateCache()

--- a/src/puzzles/012.json
+++ b/src/puzzles/012.json
@@ -29,7 +29,6 @@
         {
           "items": [
             {
-              "direction": 2,
               "type": "Portal"
             },
             {
@@ -47,14 +46,12 @@
                 null,
                 {
                   "color": "blue",
-                  "on": true,
                   "type": "Beam"
                 },
                 null,
                 null,
                 {
                   "color": "red",
-                  "on": true,
                   "type": "Beam"
                 }
               ],
@@ -74,7 +71,6 @@
         {
           "items": [
             {
-              "direction": 5,
               "type": "Portal"
             },
             {
@@ -87,11 +83,6 @@
       ],
       [
         {
-          "items": [
-            {
-              "type": "Portal"
-            }
-          ],
           "type": "Tile"
         },
         {
@@ -143,48 +134,6 @@
           "type": "Tile"
         },
         {
-          "items": [
-            {
-              "type": "Portal"
-            }
-          ],
-          "modifiers": [
-            {
-              "type": "Move"
-            }
-          ],
-          "type": "Tile"
-        }
-      ],
-      [
-        {
-          "type": "Tile"
-        },
-        {
-          "items": [
-            {
-              "rotation": 2,
-              "type": "Reflector"
-            }
-          ],
-          "modifiers": [
-            {
-              "type": "Rotate"
-            }
-          ],
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        },
-        null,
-        {
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        },
-        {
           "type": "Tile"
         }
       ],
@@ -212,15 +161,17 @@
           "modifiers": [
             {
               "type": "Lock"
-            },
-            {
-              "type": "Toggle"
             }
           ],
           "type": "Tile"
         },
+        {
+          "type": "Tile"
+        },
         null,
-        null,
+        {
+          "type": "Tile"
+        },
         {
           "items": [
             {
@@ -241,11 +192,24 @@
           "modifiers": [
             {
               "type": "Lock"
-            },
-            {
-              "type": "Toggle"
             }
           ],
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        }
+      ],
+      [
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        null,
+        null,
+        {
           "type": "Tile"
         },
         {

--- a/src/puzzles/012.json
+++ b/src/puzzles/012.json
@@ -5,21 +5,9 @@
         null,
         null,
         {
-          "items": [
-            {
-              "direction": 3,
-              "type": "Portal"
-            }
-          ],
           "type": "Tile"
         },
         {
-          "items": [
-            {
-              "direction": 4,
-              "type": "Portal"
-            }
-          ],
           "type": "Tile"
         }
       ],
@@ -29,10 +17,9 @@
         {
           "items": [
             {
-              "type": "Portal"
-            },
-            {
-              "directions": [4],
+              "directions": [
+                4
+              ],
               "type": "Wall"
             }
           ],
@@ -41,17 +28,30 @@
         {
           "items": [
             {
+              "on": true,
               "openings": [
-                null,
-                null,
+                {
+                  "color": "red",
+                  "type": "Beam"
+                },
                 {
                   "color": "blue",
                   "type": "Beam"
                 },
-                null,
-                null,
                 {
                   "color": "red",
+                  "type": "Beam"
+                },
+                {
+                  "color": "blue",
+                  "type": "Beam"
+                },
+                {
+                  "color": "red",
+                  "type": "Beam"
+                },
+                {
+                  "color": "blue",
                   "type": "Beam"
                 }
               ],
@@ -60,10 +60,10 @@
           ],
           "modifiers": [
             {
-              "type": "Rotate"
+              "type": "Lock"
             },
             {
-              "type": "Toggle"
+              "type": "Rotate"
             }
           ],
           "type": "Tile"
@@ -71,10 +71,9 @@
         {
           "items": [
             {
-              "type": "Portal"
-            },
-            {
-              "directions": [3],
+              "directions": [
+                3
+              ],
               "type": "Wall"
             }
           ],
@@ -83,9 +82,27 @@
       ],
       [
         {
-          "type": "Tile"
-        },
-        {
+          "items": [
+            {
+              "openings": [
+                null,
+                {
+                  "color": "blue",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            }
+          ],
           "type": "Tile"
         },
         {
@@ -93,18 +110,37 @@
             {
               "direction": 1,
               "type": "Portal"
-            },
-            {
-              "directions": [3, 4, 5],
-              "type": "Wall"
             }
           ],
           "modifiers": [
             {
-              "type": "Rotate"
-            },
+              "type": "Lock"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
             {
-              "type": "Swap"
+              "directions": [
+                3,
+                4,
+                5
+              ],
+              "type": "Wall"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "directions": [
+                2,
+                3,
+                4
+              ],
+              "type": "Wall"
             }
           ],
           "type": "Tile"
@@ -114,48 +150,6 @@
             {
               "direction": 0,
               "type": "Portal"
-            },
-            {
-              "directions": [2, 3, 4],
-              "type": "Wall"
-            }
-          ],
-          "modifiers": [
-            {
-              "type": "Rotate"
-            },
-            {
-              "type": "Move"
-            }
-          ],
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        }
-      ],
-      [
-        {
-          "type": "Tile"
-        },
-        {
-          "items": [
-            {
-              "openings": [
-                {
-                  "color": "blue",
-                  "type": "Beam"
-                },
-                null,
-                null,
-                null,
-                null,
-                null
-              ],
-              "type": "Terminus"
             }
           ],
           "modifiers": [
@@ -166,17 +160,9 @@
           "type": "Tile"
         },
         {
-          "type": "Tile"
-        },
-        null,
-        {
-          "type": "Tile"
-        },
-        {
           "items": [
             {
               "openings": [
-                null,
                 {
                   "color": "red",
                   "type": "Beam"
@@ -184,6 +170,85 @@
                 null,
                 null,
                 null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            }
+          ],
+          "type": "Tile"
+        }
+      ],
+      [
+        {
+          "items": [
+            {
+              "direction": 1,
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Move"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Immutable"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "openings": [
+                null,
+                {
+                  "color": "blue",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            }
+          ],
+          "type": "Tile"
+        },
+        null,
+        {
+          "items": [
+            {
+              "openings": [
+                {
+                  "color": "red",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null,
                 null
               ],
               "type": "Terminus"
@@ -197,22 +262,110 @@
           "type": "Tile"
         },
         {
+          "items": [
+            {
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Immutable"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "direction": 0,
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Move"
+            }
+          ],
           "type": "Tile"
         }
       ],
       [
         {
+          "items": [
+            {
+              "openings": [
+                null,
+                {
+                  "color": "blue",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            }
+          ],
           "type": "Tile"
         },
         {
+          "items": [
+            {
+              "direction": 1,
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Rotate"
+            }
+          ],
           "type": "Tile"
         },
         null,
         null,
         {
+          "items": [
+            {
+              "direction": 0,
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Rotate"
+            }
+          ],
           "type": "Tile"
         },
         {
+          "items": [
+            {
+              "openings": [
+                {
+                  "color": "red",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            }
+          ],
           "type": "Tile"
         }
       ]
@@ -221,7 +374,7 @@
   },
   "solution": [
     {
-      "amount": 2,
+      "amount": 6,
       "type": "Connections"
     }
   ]

--- a/src/puzzles/012.json
+++ b/src/puzzles/012.json
@@ -5,9 +5,21 @@
         null,
         null,
         {
+          "items": [
+            {
+              "direction": 3,
+              "type": "Portal"
+            }
+          ],
           "type": "Tile"
         },
         {
+          "items": [
+            {
+              "direction": 4,
+              "type": "Portal"
+            }
+          ],
           "type": "Tile"
         }
       ],
@@ -15,12 +27,117 @@
         null,
         null,
         {
+          "items": [
+            {
+              "direction": 2,
+              "type": "Portal"
+            },
+            {
+              "directions": [4],
+              "rotatable": false,
+              "type": "Wall"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "color": ["blue", "red"],
+              "openings": [
+                {
+                  "type": "Beam"
+                },
+                {
+                  "type": "Beam"
+                },
+                {
+                  "type": "Beam"
+                },
+                {
+                  "type": "Beam"
+                },
+                {
+                  "type": "Beam"
+                },
+                {
+                  "type": "Beam"
+                }
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "direction": 5,
+              "type": "Portal"
+            },
+            {
+              "directions": [3],
+              "rotatable": false,
+              "type": "Wall"
+            }
+          ],
+          "type": "Tile"
+        }
+      ],
+      [
+        {
+          "items": [
+            {
+              "type": "Portal"
+            }
+          ],
           "type": "Tile"
         },
         {
           "type": "Tile"
         },
         {
+          "items": [
+            {
+              "direction": 1,
+              "type": "Portal"
+            },
+            {
+              "directions": [3, 4, 5],
+              "rotatable": false,
+              "type": "Wall"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "direction": 0,
+              "type": "Portal"
+            },
+            {
+              "directions": [2, 3, 4],
+              "rotatable": false,
+              "type": "Wall"
+            }
+          ],
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "items": [
+            {
+              "type": "Portal"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Move"
+            }
+          ],
           "type": "Tile"
         }
       ],
@@ -29,26 +146,17 @@
           "type": "Tile"
         },
         {
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        },
-        {
-          "type": "Tile"
-        }
-      ],
-      [
-        {
-          "type": "Tile"
-        },
-        {
+          "items": [
+            {
+              "rotation": 2,
+              "type": "Reflector"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Rotate"
+            }
+          ],
           "type": "Tile"
         },
         {
@@ -70,11 +178,59 @@
           "type": "Tile"
         },
         {
+          "items": [
+            {
+              "openings": [
+                {
+                  "color": "blue",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            },
+            {
+              "type": "Toggle"
+            }
+          ],
           "type": "Tile"
         },
         null,
         null,
         {
+          "items": [
+            {
+              "openings": [
+                null,
+                {
+                  "color": "red",
+                  "type": "Beam"
+                },
+                null,
+                null,
+                null,
+                null
+              ],
+              "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Lock"
+            },
+            {
+              "type": "Toggle"
+            }
+          ],
           "type": "Tile"
         },
         {

--- a/src/puzzles/012.json
+++ b/src/puzzles/012.json
@@ -1,0 +1,93 @@
+{
+  "layout": {
+    "tiles": [
+      [
+        null,
+        null,
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        }
+      ],
+      [
+        null,
+        null,
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        }
+      ],
+      [
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        }
+      ],
+      [
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        null,
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        }
+      ],
+      [
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        },
+        null,
+        null,
+        {
+          "type": "Tile"
+        },
+        {
+          "type": "Tile"
+        }
+      ]
+    ],
+    "type": "even-r"
+  },
+  "solution": [
+    {
+      "amount": 1,
+      "type": "Connections"
+    }
+  ]
+}

--- a/src/puzzles/012.json
+++ b/src/puzzles/012.json
@@ -34,7 +34,6 @@
             },
             {
               "directions": [4],
-              "rotatable": false,
               "type": "Wall"
             }
           ],
@@ -43,28 +42,31 @@
         {
           "items": [
             {
-              "color": ["blue", "red"],
               "openings": [
+                null,
+                null,
                 {
+                  "color": "blue",
+                  "on": true,
                   "type": "Beam"
                 },
+                null,
+                null,
                 {
-                  "type": "Beam"
-                },
-                {
-                  "type": "Beam"
-                },
-                {
-                  "type": "Beam"
-                },
-                {
-                  "type": "Beam"
-                },
-                {
+                  "color": "red",
+                  "on": true,
                   "type": "Beam"
                 }
               ],
               "type": "Terminus"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Rotate"
+            },
+            {
+              "type": "Toggle"
             }
           ],
           "type": "Tile"
@@ -77,7 +79,6 @@
             },
             {
               "directions": [3],
-              "rotatable": false,
               "type": "Wall"
             }
           ],
@@ -104,8 +105,15 @@
             },
             {
               "directions": [3, 4, 5],
-              "rotatable": false,
               "type": "Wall"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Rotate"
+            },
+            {
+              "type": "Swap"
             }
           ],
           "type": "Tile"
@@ -118,8 +126,15 @@
             },
             {
               "directions": [2, 3, 4],
-              "rotatable": false,
               "type": "Wall"
+            }
+          ],
+          "modifiers": [
+            {
+              "type": "Rotate"
+            },
+            {
+              "type": "Move"
             }
           ],
           "type": "Tile"
@@ -242,7 +257,7 @@
   },
   "solution": [
     {
-      "amount": 1,
+      "amount": 2,
       "type": "Connections"
     }
   ]

--- a/src/puzzles/index.js
+++ b/src/puzzles/index.js
@@ -10,6 +10,7 @@ const puzzles = {
   '009': require('./009.json'),
   '010': require('./010.json'),
   '011': require('./011.json'),
+  '012': require('./012.json'),
   test_infinite_loop: require('./test/infiniteLoop.json'),
   test_layout: require('./test/layout'),
   test_portal: require('./test/portal.json'),

--- a/src/puzzles/test/layout.js
+++ b/src/puzzles/test/layout.js
@@ -1,16 +1,16 @@
 // TODO: this file can be removed when the puzzle editor is created
 const layout = [
-  ['o', 'x', 'x', 'x'],
-  ['x', 'x', 'x', 'x'],
-  ['x', 'x', 'x', 'x', 'x'],
-  ['x', 'x', 'x', 'x'],
-  ['o', 'x', 'x', 'x']
+  ['o', 'o', 'x', 'x'],
+  ['o', 'o', 'x', 'x', 'x'],
+  ['x', 'x', 'x', 'x', 'x', 'x'],
+  ['x', 'x', 'x', 'o', 'x', 'x', 'x'],
+  ['x', 'x', 'o', 'o', 'x', 'x']
 ]
 
 export default {
   layout: {
-    tiles: layout.map((column) => column.map((item) => item === 'x' ? { type: 'Tile' } : null))
-    // type: 'even-r'
+    tiles: layout.map((column) => column.map((item) => item === 'x' ? { type: 'Tile' } : null)),
+    type: 'even-r'
   },
   solution: [
     { amount: 100, type: 'Connections' }

--- a/test/puzzles/012.js
+++ b/test/puzzles/012.js
@@ -12,6 +12,62 @@ describe('Puzzle 012', function () {
     await puzzle.clickTile(1, 3)
     await puzzle.clickModifier('rotate')
 
+    await puzzle.clickTile(3, 0)
+    await puzzle.clickModifier('move')
+    await puzzle.clickTile(0, 3)
+    await puzzle.isMasked()
+    await puzzle.clickTile(3, 5)
+
+    await puzzle.clickTile(3, 6)
+    await puzzle.clickModifier('move')
+    await puzzle.clickTile(0, 2)
+    await puzzle.isMasked()
+    await puzzle.clickTile(3, 1)
+
+    await puzzle.clickTile(4, 1)
+    await puzzle.clickModifier('rotate', { times: 3 })
+
+    await puzzle.clickTile(4, 4)
+    await puzzle.clickModifier('rotate', { times: 3 })
+
+    await puzzle.clickTile(3, 0)
+    await puzzle.selectModifier('move')
+    await puzzle.clickTile(4, 1)
+    await puzzle.clickModifier('move')
+    await puzzle.clickTile(1, 4)
+    await puzzle.isMasked()
+    await puzzle.clickTile(3, 1)
+
+    await puzzle.clickTile(3, 6)
+    await puzzle.selectModifier('move')
+    await puzzle.clickTile(4, 4)
+    await puzzle.clickModifier('move')
+    await puzzle.clickTile(1, 2)
+    await puzzle.isMasked()
+    await puzzle.clickTile(3, 5)
+
+    await puzzle.clickTile(4, 1)
+    await puzzle.selectModifier('move')
+    await puzzle.clickTile(3, 2)
+    await puzzle.clickModifier('move')
+    await puzzle.clickTile(2, 2)
+
+    await puzzle.clickTile(4, 4)
+    await puzzle.selectModifier('move')
+    await puzzle.clickTile(3, 4)
+    await puzzle.clickModifier('move')
+    await puzzle.clickTile(2, 3)
+
+    await puzzle.clickTile(4, 1)
+    await puzzle.selectModifier('rotate')
+    await puzzle.clickTile(2, 0)
+    await puzzle.clickModifier('rotate', { times: 2 })
+
+    await puzzle.clickTile(4, 4)
+    await puzzle.selectModifier('rotate')
+    await puzzle.clickTile(2, 5)
+    await puzzle.clickModifier('rotate', { times: 4 })
+
     assert(await puzzle.isSolved())
   })
 })

--- a/test/puzzles/012.js
+++ b/test/puzzles/012.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha */
+const { PuzzleFixture } = require('../fixtures.js')
+const assert = require('assert')
+
+describe('Puzzle 012', function () {
+  const puzzle = new PuzzleFixture('012')
+
+  after(puzzle.after)
+  before(puzzle.before)
+
+  it('should be solved', async function () {
+    await puzzle.clickTile(1, 3)
+    await puzzle.clickModifier('rotate')
+
+    assert(await puzzle.isSolved())
+  })
+})


### PR DESCRIPTION
This puzzle further strengthens the rules introduced in previous portal puzzles. It is also the most difficult portal puzzle to this point.

This PR also includes a number of other bug fixes and improvements:
- Beam step-specific state (which is ultimately stored in the terminal opening state configuration, which is the basis for beam state configuration) has been refactored so that it is attached to specific steps and will be automatically added and removed when the steps are added and removed. This state is currently only used by portals, but could be used by other things in the future.
- Items can now specify 'immutable' in the state configuration, which should basically act the same as setting each individual modifier key to false (e.g. movable, toggleable, rotatable, etc.). Beam and wall items will have immutable set by default.
- Item IDs are now retained in cache, making them stable IDs. Previously, item IDs were re-generated when the page was refreshed, which meant that if an item had been moved its ID could change. The generation and storage of item IDs on the loading of a puzzle is not stored as a delta, so it won't show up as a move and won't be undo-able.
- Swap now requires tiles to contain movable items, instead of any items.
- Masks are now re-evaluated when dequeued, with the potential to cancel the mask. This is because state can change in between when the mask is queued and when it gets processed. For example, if multiple portals are reached at the same time, the resolution of one of the portals may cause a subsequent portal mask to no longer be valid.
- The tile indicator has been refactored to apply an "is not immutable" filter. The primary purpose of the indicator is to show the user they can interact with something in that tile, and immutable modifiers are not interactable, so it just creates noise. The lock and immutable modifiers mostly apply when moving something anyways.
- Fixed getting color elements for a newly selected tile, if it contained merge beams it was throwing an error using because it was using `step.color` instead of `step.colors` (which is an array).
- Updated the portal collision logic in `beam.onCollision` was not handling every case.
- Fixed state index not being updated correctly if `keepDelta` was false on state update.
- Fixed state actions like undo and redo not being properly prevented even if they were disabled visually. The reset action is also now being disabled in cases where it should be.
- Fixed the puzzle mask queue not being emptied when the puzzle was reloaded, which caused some strange undo/redo behaviors.