### PR TITLE
Improve action UX and state storage

### DIFF
--- a/src/components/item.js
+++ b/src/components/item.js
@@ -24,7 +24,7 @@ export class Item extends Stateful {
     this.immutable ??= state?.immutable ?? false
     this.type = state?.type ?? configuration?.type
     if (this.type === undefined) {
-      console.debug(`[Item:${this.id}]`, state)
+      console.debug(`[Item:${this.id}]`, state, configuration)
       throw new Error('Item must have type defined')
     }
 

--- a/src/components/itemFactory.js
+++ b/src/components/itemFactory.js
@@ -5,7 +5,7 @@ import { Reflector } from './items/reflector'
 import { Wall } from './items/wall'
 import { Item } from './item'
 
-export function itemFactory (parent, state, configuration) {
+export function itemFactory (parent, state, index) {
   let item
 
   switch (state.type) {

--- a/src/components/items/tile.js
+++ b/src/components/items/tile.js
@@ -24,11 +24,11 @@ export class Tile extends Item {
 
     // These need to be last, since they reference this
     this.items = (state.items || [])
-      .map((state) => itemFactory(this, state))
+      .map((state, index) => itemFactory(this, state, index))
       .filter((item) => item !== undefined)
 
     this.modifiers = (state.modifiers || [])
-      .map((state) => modifierFactory(this, state))
+      .map((state, index) => modifierFactory(this, state, index))
       .filter((modifier) => modifier !== undefined)
 
     this.modifiers.forEach((modifier) => this.updateIcon(modifier))

--- a/src/components/items/tile.js
+++ b/src/components/items/tile.js
@@ -5,7 +5,6 @@ import { emitEvent, getPointBetween } from '../util'
 import { modifierFactory } from '../modifierFactory'
 
 export class Tile extends Item {
-  icons = []
   selected = false
 
   #ui
@@ -59,7 +58,7 @@ export class Tile extends Item {
   }
 
   getState () {
-    const state = { type: this.type }
+    const state = { id: this.id, type: this.type }
 
     // Filter out beams, which are not stored in state
     const items = this.items.filter((item) => item.type !== Item.Types.beam).map((item) => item.getState())

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -35,7 +35,7 @@ export class Layout extends Stateful {
     this.layers.items = new Layer()
 
     this.modifiers = (state.modifiers || [])
-      .map((state) => modifierFactory(null, state))
+      .map((state, index) => modifierFactory(null, state, index))
       .filter((modifier) => modifier !== undefined)
 
     // Find the widest row

--- a/src/components/modifier.js
+++ b/src/components/modifier.js
@@ -1,4 +1,4 @@
-import { capitalize, emitEvent, uniqueId } from './util'
+import { capitalize, emitEvent } from './util'
 import { Stateful } from './stateful'
 import { EventListeners } from './eventListeners'
 import { Interact } from './interact'
@@ -7,6 +7,9 @@ import { Icons } from './icons'
 import { Tile } from './items/tile'
 
 const modifiers = document.getElementById('modifiers')
+
+// Use incrementing IDs to preserve sort order
+let uniqueId = 0
 
 export class Modifier extends Stateful {
   #container
@@ -26,7 +29,7 @@ export class Modifier extends Stateful {
 
   constructor (tile, state) {
     // Retain ID from state if it exists, otherwise generate a new one
-    state.id ??= uniqueId()
+    state.id ??= uniqueId++
     super(state)
 
     this.id = state.id

--- a/src/components/modifier.js
+++ b/src/components/modifier.js
@@ -1,4 +1,4 @@
-import { capitalize, emitEvent } from './util'
+import { capitalize, emitEvent, uniqueId } from './util'
 import { Stateful } from './stateful'
 import { EventListeners } from './eventListeners'
 import { Interact } from './interact'
@@ -7,8 +7,6 @@ import { Icons } from './icons'
 import { Tile } from './items/tile'
 
 const modifiers = document.getElementById('modifiers')
-
-let uniqueId = 0
 
 export class Modifier extends Stateful {
   #container
@@ -19,7 +17,6 @@ export class Modifier extends Stateful {
   configuration
   element
   disabled = false
-  id = uniqueId++
   immutable = false
   name
   parent
@@ -28,8 +25,12 @@ export class Modifier extends Stateful {
   type
 
   constructor (tile, state) {
+    console.log(state.id)
+    state.id ??= uniqueId()
+
     super(state)
 
+    this.id = state.id
     this.parent = tile
     this.type = state.type
   }
@@ -142,6 +143,9 @@ export class Modifier extends Stateful {
           break
         }
       }
+
+      // Keep the tile icon in sync
+      this.parent?.updateIcon(this)
     }
 
     this.#down = false

--- a/src/components/modifier.js
+++ b/src/components/modifier.js
@@ -25,9 +25,8 @@ export class Modifier extends Stateful {
   type
 
   constructor (tile, state) {
-    console.log(state.id)
+    // Retain ID from state if it exists, otherwise generate a new one
     state.id ??= uniqueId()
-
     super(state)
 
     this.id = state.id

--- a/src/components/modifierFactory.js
+++ b/src/components/modifierFactory.js
@@ -6,30 +6,30 @@ import { Toggle } from './modifiers/toggle'
 import { Modifier } from './modifier'
 import { Swap } from './modifiers/swap'
 
-export function modifierFactory (tile, configuration) {
+export function modifierFactory (parent, state, index) {
   let modifier
 
-  switch (configuration.type) {
+  switch (state.type) {
     case Modifier.Types.immutable:
-      modifier = new Immutable(tile, configuration)
+      modifier = new Immutable(...arguments)
       break
     case Modifier.Types.lock:
-      modifier = new Lock(tile, configuration)
+      modifier = new Lock(...arguments)
       break
     case Modifier.Types.move:
-      modifier = new Move(tile, configuration)
+      modifier = new Move(...arguments)
       break
     case Modifier.Types.rotate:
-      modifier = new Rotate(tile, configuration)
+      modifier = new Rotate(...arguments)
       break
     case Modifier.Types.swap:
-      modifier = new Swap(tile, configuration)
+      modifier = new Swap(...arguments)
       break
     case Modifier.Types.toggle:
-      modifier = new Toggle(tile, configuration)
+      modifier = new Toggle(...arguments)
       break
     default:
-      console.error('Ignoring modifier with unknown type:', configuration.type)
+      console.error('Ignoring modifier with unknown type:', state.type)
       break
   }
 

--- a/src/components/modifiers/toggle.js
+++ b/src/components/modifiers/toggle.js
@@ -5,18 +5,19 @@ export class Toggle extends Modifier {
   on
   title = 'Toggle'
 
-  constructor (tile, { on }) {
+  constructor (tile, state) {
     super(...arguments)
 
-    this.on = on || false
+    // TODO: refactor to use 'toggled' everywhere
+    this.on = state.on || this.parent?.items.some((item => item.on || item.toggled))
     this.name = this.getName()
   }
 
   attach (tile) {
     super.attach(tile)
-    // Consider the modifier toggled if there is at least one toggled item in the tile
-    // TODO: refactor to be 'toggled' everywhere
-    this.on = this.tile?.items.some((item) => item.on || item.toggled)
+
+    // TODO: refactor to use 'toggled' everywhere
+    this.on = this.tile?.items.some((item => item.on || item.toggled))
     this.update({ name: this.getName() })
   }
 

--- a/src/components/modifiers/toggle.js
+++ b/src/components/modifiers/toggle.js
@@ -9,7 +9,7 @@ export class Toggle extends Modifier {
     super(...arguments)
 
     // TODO: refactor to use 'toggled' everywhere
-    this.on = state.on || this.parent?.items.some((item => item.on || item.toggled))
+    this.on = state.on || this.parent?.items.some(item => item.on || item.toggled)
     this.name = this.getName()
   }
 
@@ -17,7 +17,7 @@ export class Toggle extends Modifier {
     super.attach(tile)
 
     // TODO: refactor to use 'toggled' everywhere
-    this.on = this.tile?.items.some((item => item.on || item.toggled))
+    this.on = this.tile?.items.some(item => item.on || item.toggled)
     this.update({ name: this.getName() })
   }
 
@@ -27,7 +27,7 @@ export class Toggle extends Modifier {
 
   moveFilter (tile) {
     // Filter out tiles that contain no toggleable items
-    return super.moveFilter(tile) || !tile.items.some((item) => item.toggleable)
+    return super.moveFilter(tile) || !tile.items.some(item => item.toggleable)
   }
 
   onTap (event) {

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -252,9 +252,9 @@ export class Puzzle {
 
   #getModifiers (tile) {
     // Sort by ID to ensure they always appear in the same order regardless of ownership
-    return this.layout.modifiers.concat(tile?.modifiers || [])
+    return (tile?.modifiers || []).concat(this.layout.modifiers)
       .filter((modifier) => !modifier.immutable)
-      .sort((a, b) => a.id.localeCompare(b.id))
+      .sort((a, b) => a.id - b.id)
   }
 
   #next () {

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -251,7 +251,7 @@ export class Puzzle {
     // Sort by ID to ensure they always appear in the same order regardless of ownership
     return this.layout.modifiers.concat(tile?.modifiers || [])
       .filter((modifier) => !modifier.immutable)
-      .sort((a, b) => a.id - b.id)
+      .sort((a, b) => a.id.localeCompare(b.id))
   }
 
   #next () {
@@ -482,7 +482,7 @@ export class Puzzle {
       : undefined
 
     this.updateSelectedTile(selectedTile)
-    this.updateState(false)
+    this.updateState()
     this.update()
   }
 

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -91,6 +91,10 @@ export class Puzzle {
     this.select()
   }
 
+  addMove () {
+    return this.#state.addMove()
+  }
+
   centerOnTile (offset) {
     const tile = this.layout.getTileByOffset(offset)
     paper.view.center = tile.center
@@ -228,12 +232,11 @@ export class Puzzle {
     return previouslySelectedTile
   }
 
-  updateState (keepDelta = true) {
-    this.#state.update(Object.assign(this.#state.getCurrent(), { layout: this.layout.getState() }), keepDelta)
+  updateState () {
+    this.#state.update(Object.assign(this.#state.getCurrent(), { layout: this.layout.getState() }))
     this.#updateActions()
-    if (keepDelta) {
-      emitEvent(Puzzle.Events.Updated, { state: this.#state })
-    }
+
+    emitEvent(Puzzle.Events.Updated, { state: this.#state })
   }
 
   #addLayers () {
@@ -350,6 +353,7 @@ export class Puzzle {
         .forEach((other) => other.update({ disabled: true }))
     }
 
+    this.addMove()
     this.updateState()
 
     this.#beams
@@ -385,7 +389,8 @@ export class Puzzle {
     emitEvent(Puzzle.Events.Solved)
   }
 
-  #onStateUpdate () {
+  #onStateUpdate (event) {
+    console.debug('Puzzle.#onStateUpdate()', event)
     this.updateState()
   }
 

--- a/src/components/solution.js
+++ b/src/components/solution.js
@@ -166,7 +166,7 @@ class Moves extends SolutionCondition {
 
   update (event) {
     console.debug('Moves.update', event)
-    this.#moves = event.detail.state.moves()
+    this.#moves = event.detail.state.moves().length
     this.#completed.textContent = this.#moves.toString()
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -229,7 +229,7 @@
     </main>
     <footer id="footer">
       <div id="footer-message" class="message"></div>
-      <ul id="modifiers" class="menu modifiers"></ul>
+      <ul id="modifiers" class="menu"></ul>
     </footer>
     <div id="symbols">
       <svg id="icon-immutable" xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#000000"><path d="M480-80q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q54 0 104-17.5t92-50.5L228-676q-33 42-50.5 92T160-480q0 134 93 227t227 93Zm252-124q33-42 50.5-92T800-480q0-134-93-227t-227-93q-54 0-104 17.5T284-732l448 448Z"/></svg>

--- a/src/styles.css
+++ b/src/styles.css
@@ -161,7 +161,7 @@ body > header {
 body > footer {
   display: none;
   bottom: 1em;
-  flex-direction: column;
+  flex-flow: column wrap;
   left: 0;
   right: 0;
 }
@@ -227,7 +227,17 @@ main {
 
 #modifiers {
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
+  margin: -1px 0;
+  user-select: none;
+  /* For iOS/Safari. */
+  -webkit-user-select: none;
+}
+
+#modifiers li {
+  border: 1px solid #ddd;
+  margin: 0 0 -1px -1px;
 }
 
 #puzzle-id {
@@ -270,9 +280,7 @@ main {
 #solution {
   align-items: center;
   cursor: default;
-  display: flex;
   line-height: 24px;
-  list-style: none;
 }
 
 #solution .icon {
@@ -429,19 +437,13 @@ main {
   display: none;
 }
 
-.modifiers {
-  user-select: none;
-  /* For iOS/Safari. */
-  -webkit-user-select: none;
-}
-
 .puzzle-error .flex-left,
 .puzzle-error .flex-right {
   flex: 0;
 }
 
 .puzzle-error:not(.puzzle-loaded) #puzzle,
-.puzzle-error .modifiers {
+.puzzle-error #modifiers {
   display: none;
 }
 
@@ -462,16 +464,9 @@ main {
 }
 
 @media (max-width: 600px) {
-  body > header,
-  body > footer {
-    /*flex-wrap: wrap;*/
+  body > header {
     max-width: 100%;
     width: 100%;
-  }
-
-  body > footer {
-    border-radius: 0;
-    bottom: 0;
   }
 
   body > header {


### PR DESCRIPTION
Leave actions centered and ensure that they will wrap as needed on smaller devices. Also ensure that they are listed in the toolbar in the order they are defined in configuration (global first, then tile level), and that the order sticks even when ownership changes.

As part of this change, the concept of 'moves' has been added to the cached state which allows explicitly defining when a user has made a move, instead of just counting each state update as a move (or throwing it out entirely). This also allows the puzzle to assign IDs to everything the first time it starts up and re-use those IDs from cache. That ensures IDs will not change between page loads, which can make it easier to debug and also allows for logic related to IDs (such as sorting) to be persistent.