### PR TITLE
Fix minor state bugs

### DIFF
--- a/src/components/state.js
+++ b/src/components/state.js
@@ -15,7 +15,6 @@ export class State {
   #version
 
   constructor (id, original, deltas, moveIndex, moves, selectedTile, version) {
-    console.log(moveIndex)
     this.#id = id
     this.#original = original
     this.#deltas = deltas || []
@@ -208,9 +207,7 @@ export class State {
 
     // Then apply every delta until the currently active delta
     const deltaIndex = this.getDeltaIndex()
-
-    console.log(this.toString(), 'resetCurrent', deltaIndex)
-
+    console.debug(this.toString(), 'resetCurrent', deltaIndex)
     this.#deltas.filter((delta, index) => index <= deltaIndex).forEach((delta) => this.#apply(delta))
   }
 
@@ -301,7 +298,6 @@ export class State {
       pathSegments.filter((path) => !Puzzles.has(path)).some((segment, index) => {
         try {
           state = State.fromEncoded(segment)
-          id = state.getId()
         } catch (e) {
           console.debug(`Could not parse state from path segment '${index}'`, e)
         }


### PR DESCRIPTION
Remove `console.log` in favor of `console.debug`. Fix a bug when trying to reference a property that may not exist.