### PR TITLE
Fix move actions not locking to tiles. Fixes #28

### DIFF
--- a/src/components/modifier.js
+++ b/src/components/modifier.js
@@ -97,7 +97,7 @@ export class Modifier extends Stateful {
   }
 
   dispatchEvent (event, detail) {
-    emitEvent(event, Object.assign({}, detail || {}, { modifier: this, tile: this.tile }))
+    emitEvent(event, Object.assign({ tile: this.tile }, detail || {}, { modifier: this }))
   }
 
   equals (other) {

--- a/src/components/modifiers/move.js
+++ b/src/components/modifiers/move.js
@@ -41,6 +41,8 @@ export class Move extends Modifier {
     items.forEach((item) => item.move(tile))
     return {
       moved: [Move.data(this.tile, tile, items)],
+      selectedTile: tile,
+      tile: this.tile,
       tiles: [this.tile, tile]
     }
   }
@@ -60,9 +62,6 @@ export class Move extends Modifier {
 
     if (tile) {
       const data = this.moveItems(tile)
-
-      puzzle.updateSelectedTile(tile)
-
       this.dispatchEvent(Modifier.Events.Invoked, data)
     }
 

--- a/src/components/modifiers/swap.js
+++ b/src/components/modifiers/swap.js
@@ -15,6 +15,8 @@ export class Swap extends Move {
 
     return {
       moved: [Move.data(this.tile, tile, fromItems), Move.data(tile, this.tile, toItems)],
+      selectedTile: tile,
+      tile: this.tile,
       tiles: [this.tile, tile]
     }
   }

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -353,6 +353,10 @@ export class Puzzle {
         .forEach((other) => other.update({ disabled: true }))
     }
 
+    if (event.detail.selectedTile) {
+      this.updateSelectedTile(event.detail.selectedTile)
+    }
+
     this.addMove()
     this.updateState()
 


### PR DESCRIPTION
There were two problems here. The currently selected tile was changing before the modifier was invoked and it was referencing the wrong tile. This is a problem for move actions because the a new tile is selected during modification (the 'to' tile).