### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,6 @@ jobs:
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
   gh-pages:
-    needs: build-info
-    if: needs.build-info.outputs.tag != needs.build-info.outputs.latest-tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,7 +60,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npx gh-pages -d dist -u "github-actions-bot <support+actions@github.com>" --nojekyll
+          npx gh-pages -d dist/web -u "github-actions-bot <support+actions@github.com>" --nojekyll
   make:
     needs: build-info
     if: needs.build-info.outputs.tag != needs.build-info.outputs.latest-tag


### PR DESCRIPTION
Fixes path to web build, which is now at dist/web. Also allows gh-pages to be updated regardless of whether or not the build number is being bumped, since there is no downside to doing it, and it can be useful in cases like this.

Basically the package version bump is now tied to Steam deployment, and not to gh-pages deployment.