### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           cd artifacts/web
           zip -r "beaming-${VERSION}.zip" .
           cd "$BASE_PATH"
-          mv artifacts/**/*.{deb,exe,zip} release
+          mv artifacts/**/*.{exe,zip} release
           tree release
       - name: Create release
         env:


### PR DESCRIPTION
Don't run `gh-pages` until after `build-info` runs (which depends on `test`). Also remove `.deb` files from the artifacts `mv` glob -- they aren't being built anymore.