### PR TITLE
Fixes #106, #107, #108. Also adds 'share' profile for share URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "beaming",
   "author": "Kyle Florence",
   "description": "A browser-based puzzle game that involves directing beams through a hexagonal grid.",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "CC BY-NC 4.0",
   "main": "src/electron/main.js",
   "type": "module",

--- a/src/components/filter.js
+++ b/src/components/filter.js
@@ -14,6 +14,10 @@ export class Filter {
 
   apply () {}
 
+  toString () {
+    return `[Filter:${this.type}->${this.name}]`
+  }
+
   static Name
   static Type
 

--- a/src/components/import.js
+++ b/src/components/import.js
@@ -88,8 +88,8 @@ export class ImportFilterModifierInclusion extends ImportFilter {
 }
 
 export class ImportFilterPuzzleSolved extends ImportFilter {
-  apply (state) {
-    return this.state.solved === (state.getSolution() !== undefined)
+  apply (state, ref) {
+    return this.state.solved === (state.getSolution() !== undefined || ref.solution !== undefined)
   }
 
   static Name = ImportFilter.Names.Solved
@@ -134,8 +134,8 @@ export class ImportFilterPuzzleUnlocked extends ImportFilter {
 }
 
 export class ImportFilterTileInSolution extends ImportFilter {
-  apply (state, offset, tile) {
-    return this.state.inSolution === state.getSolution()?.includes(offset.toString())
+  apply (state, offset, tile, ref) {
+    return this.state.inSolution === (state.getSolution() ?? ref.solution)?.includes(offset.toString())
   }
 
   static Name = ImportFilter.Names.InSolution
@@ -191,6 +191,15 @@ export class Import {
               ImportFilterTileInSolution.schema()
             ],
             headerTemplate: 'filter {{i1}}'
+          },
+          type: 'array'
+        },
+        solution: {
+          items: {
+            type: 'string'
+          },
+          options: {
+            hidden: true
           },
           type: 'array'
         },

--- a/src/components/items/tile.js
+++ b/src/components/items/tile.js
@@ -238,7 +238,6 @@ export class Tile extends Item {
   static Flags = Object.freeze({
     Copy: new Tile.Flag('copy'),
     Edit: new Tile.Flag('edit'),
-    // TODO implement hidden
     Hidden: new Tile.Flag('hidden'),
     Placeholder: new Tile.Flag('placeholder'),
     Selected: new Tile.Flag('selected')

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -117,7 +117,7 @@ export class Layout extends Stateful {
             flags.add(Tile.Flags.Hidden)
           }
 
-          if (!ref.unlocked || !tileFilters.every((filter) => filter.apply(source, tileOffset, tile))) {
+          if (!ref.unlocked || !tileFilters.every((filter) => filter.apply(source, tileOffset, tile, ref))) {
             flags.add(Tile.Flags.Placeholder)
           }
 

--- a/src/components/modifiers/puzzle.js
+++ b/src/components/modifiers/puzzle.js
@@ -19,6 +19,7 @@ export class PuzzleModifier extends Modifier {
 
     puzzle.headerMessages.add(`You've unlocked puzzle '${state.id}'!`)
     puzzle.layout.unlock(state.id)
+    puzzle.updateState()
 
     Game.updatePuzzles([State.ContextKeys.Play])
   }

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -398,7 +398,7 @@ export class Puzzle {
 
     id = state.getId()
 
-    const isUnlocked = !Puzzles.has(id) || State.fromCache(id) !== undefined
+    const isUnlocked = !Puzzles.has(id) || State.fromCache(id) !== undefined || this.layout?.getImport(id)?.unlocked
     if (!(isUnlocked || state.getCurrent().unlocked || params.has(State.ParamKeys.Unlock))) {
       return this.onError('This puzzle has not been unlocked yet.')
     }
@@ -426,7 +426,7 @@ export class Puzzle {
         return
       case Item.Types.Tile:
         tile = this.layout.getTile(result.data.coordinates.offset)
-        if (Puzzle.unSelectableTileFlags.some((flag) => tile.flags.has(flag)) && !Game.is(Game.States.Edit)) {
+        if (Puzzle.unSelectableTileFlags.some((flag) => tile.flags.has(flag))) {
           // Ignore taps on un-selectable tiles
           tile = undefined
         }

--- a/src/components/settings/profile.js
+++ b/src/components/settings/profile.js
@@ -5,7 +5,7 @@ import { emitEvent } from '../util.js'
 const $profiles = document.getElementById('settings-profile')
 const $name = document.getElementById('settings-profile-name')
 
-function add (profile, selected = Storage.Profile.get() ?? Storage.Profiles.Default) {
+function add (profile, selected = Storage.Profile.get() ?? Storage.ProfilesByName.Default) {
   const li = document.createElement('li')
   li.classList.add('profile')
   li.classList.toggle('selected', profile.id === selected.id)
@@ -16,7 +16,7 @@ function add (profile, selected = Storage.Profile.get() ?? Storage.Profiles.Defa
   left.textContent = profile.name
   li.append(left)
 
-  if (profile.id !== Storage.Profiles.Default.id) {
+  if (!Storage.ProfileIds.includes(profile.id)) {
     const right = document.createElement('div')
     right.classList.add('flex-right')
 
@@ -33,6 +33,13 @@ function add (profile, selected = Storage.Profile.get() ?? Storage.Profiles.Defa
   }
 
   $profiles.append(li)
+}
+
+export function setProfile (id) {
+  Storage.Profiles.set(id)
+  const $profile = $profiles.querySelector(`[data-id='${id}']`)
+  $profiles.querySelector('.selected').classList.toggle('selected')
+  $profile.classList.add('selected')
 }
 
 document.getElementById('settings-profile-create').addEventListener('click', () => {
@@ -75,5 +82,5 @@ $profiles.addEventListener('click', (event) => {
   }
 })
 
-const profiles = [Storage.Profiles.Default].concat(Storage.Profiles.get())
+const profiles = Object.values(Storage.ProfilesByName).concat(Storage.Profiles.get())
 profiles.forEach((profile) => add(profile))

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -11,6 +11,7 @@ import {
   url
 } from './util'
 import { Game } from './game.js'
+import { setProfile } from './settings/profile.js'
 
 const history = window.history
 
@@ -426,7 +427,11 @@ export class State {
       try {
         state = State.fromEncoded(value)
         id = state.getId()
-        console.debug(`Successfully resolved locally cached state for puzzle ID '${id}'.`, state)
+        console.debug(`Successfully resolved cached state for puzzle ID '${id}'.`, state)
+        if (cached === null) {
+          console.debug('User loaded a share URL, setting profile to "share"')
+          setProfile(Storage.ProfilesByName.Share.id)
+        }
         return state
       } catch (e) {
         console.debug(`Could not decode value: ${value}`, e)

--- a/src/components/storage.js
+++ b/src/components/storage.js
@@ -60,8 +60,8 @@ export class Storage {
     id
     name
 
-    constructor (name) {
-      this.id = uniqueId()
+    constructor (name, id) {
+      this.id = id ?? uniqueId()
       this.name = name
     }
 
@@ -77,6 +77,16 @@ export class Storage {
     }
   }
 
+  static ProfilesByName = Object.freeze({
+    Default: new Storage.Profile('default', 'default'),
+    Share: new Storage.Profile('share', 'share')
+  })
+
+  static ProfilesById = Object.freeze(Object.fromEntries(
+    Object.values(Storage.ProfilesByName).map((profile) => [profile.id, profile])))
+
+  static ProfileIds = Object.keys(Storage.ProfilesById)
+
   static Profiles = class {
     static add (name) {
       const profiles = Storage.Profiles.get()
@@ -87,8 +97,9 @@ export class Storage {
     }
 
     static get (id) {
-      if (id === Storage.Profiles.Default.id) {
-        return Storage.Profiles.Default
+      const def = Storage.ProfilesById[id]
+      if (def) {
+        return def
       }
 
       const profiles = JSON.parse(localStorage.getItem(getKey(Storage.Prefix, Storage.Keys.Profiles)) ?? '[]')
@@ -113,7 +124,7 @@ export class Storage {
         throw new Error(`Invalid profile id: ${id}`)
       }
 
-      if (profile.id === Storage.Profiles.Default.id) {
+      if (profile.id === Storage.ProfilesByName.Default) {
         localStorage.removeItem(getKey(Storage.Prefix, Storage.Keys.Profile))
       } else {
         localStorage.setItem(getKey(Storage.Prefix, Storage.Keys.Profile), id)
@@ -122,8 +133,6 @@ export class Storage {
       emitEvent(Storage.Profiles.Events.Updated, { profile })
       return profile
     }
-
-    static Default = new Storage.Profile('default')
 
     static Events = Object.freeze({
       Update: getKey(Storage.Key, Storage.Keys.Profiles, 'update'),

--- a/src/puzzles/001.json
+++ b/src/puzzles/001.json
@@ -1566,10 +1566,6 @@
             {
               "type": "lock",
               "id": "4cc3d75b"
-            },
-            {
-              "type": "immutable",
-              "id": "2e9f8691"
             }
           ],
           "items": [
@@ -2174,11 +2170,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -2303,11 +2294,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -2411,11 +2397,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -2484,11 +2465,6 @@
           "c": 3
         },
         "filters": [
-          {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
           {
             "type": "tile",
             "name": "in-solution",
@@ -2605,11 +2581,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -2709,11 +2680,6 @@
           "c": 0
         },
         "filters": [
-          {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
           {
             "type": "puzzle",
             "name": "unlocked",
@@ -2863,11 +2829,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -2943,11 +2904,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -2966,11 +2922,6 @@
           "c": -4
         },
         "filters": [
-          {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
           {
             "type": "tile",
             "name": "in-solution",
@@ -2991,11 +2942,6 @@
         },
         "filters": [
           {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
-          {
             "type": "tile",
             "name": "in-solution",
             "inSolution": true
@@ -3014,11 +2960,6 @@
           "c": 0
         },
         "filters": [
-          {
-            "type": "puzzle",
-            "name": "solved",
-            "solved": true
-          },
           {
             "type": "tile",
             "name": "in-solution",

--- a/src/puzzles/index.js
+++ b/src/puzzles/index.js
@@ -20,13 +20,13 @@ export class Puzzles {
       : State.getIds(context)
     const processedIds = []
 
-    function addItem (id) {
+    function addItem (id, ref) {
       if (processedIds.includes(id)) {
         return
       }
 
       const state = State.fromCache(id, context)
-      const puzzle = puzzles[id] ?? state?.getConfig()
+      const puzzle = state?.getCurrent() ?? puzzles[id]
 
       if (!puzzle) {
         return
@@ -37,7 +37,7 @@ export class Puzzles {
       li.classList.toggle('custom', !Puzzles.has(id))
       li.classList.toggle('selected', id === currentId)
       li.classList.toggle('solved', state?.getSolution() !== undefined)
-      li.classList.toggle('unlocked', puzzle.unlocked === true || state !== undefined)
+      li.classList.toggle('unlocked', ref?.unlocked || puzzle.unlocked || state !== undefined)
       li.dataset.id = id
 
       const div = document.createElement('div')
@@ -58,7 +58,7 @@ export class Puzzles {
       if (context === State.ContextKeys.Play && puzzle.layout?.imports?.length) {
         const ul = document.createElement('ul')
         ul.classList.add('imports')
-        puzzle.layout.imports.forEach((ref) => ul.append(addItem(ref.id)))
+        puzzle.layout.imports.forEach((ref) => ul.append(addItem(ref.id, ref)))
         li.append(ul)
       }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -145,7 +145,8 @@ dialog.fullscreen {
   height: 100vh;
   left: 0;
   margin: 0;
-  max-height: 100vh;
+  /* Can't use vh here for mobile. See: https://developer.chrome.com/blog/url-bar-resizing */
+  max-height: 100%;
   max-width: 100vw;
   top: 0;
   width: 100vw;


### PR DESCRIPTION
While debugging the fix for #107, I noticed that share URLs are problematic in that they override the state of whatever profile is currently in use. To solve that, I've added a new 'share' profile that will be switched to automatically when loading puzzle state from the URL. This will isolate the local cache into the 'share' profile, with the additional perk that the cache will still be available if the user navigates away from the URL. The user will need to switch back to the other profile to pick up where they left off before loading the share URL (may want to add a notice about that somewhere at some point).

This also includes various other small bug fixes around visibility of unlocked puzzles within a larger puzzle. It should now show the unlocked puzzle when the puzzle is actually unlocked, rather than when it is solved (although it would sometimes do that anyways due to a bug, previously). This commit will also include the solution for each imported puzzle along with the import configuration (if the user has solved it), which will allow it to properly display tiles in the main puzzle for share URLs. But this will likely be revisited with #109.