### PR TITLE
Update logic for puzzles with empty solutions. Fixes #112

### DIFF
--- a/src/components/import.js
+++ b/src/components/import.js
@@ -136,7 +136,9 @@ export class ImportFilterPuzzleUnlocked extends ImportFilter {
 
 export class ImportFilterTileInSolution extends ImportFilter {
   apply (state, offset, tile, ref) {
-    return this.state.inSolution === (state.getSolution() ?? ref.solution)?.includes(offset.toString())
+    const solution = (state.getSolution() ?? ref.solution)
+    // An empty solution will include all tiles
+    return this.state.inSolution === (solution?.length === 0 || solution?.includes(offset.toString()))
   }
 
   static Name = ImportFilter.Names.InSolution

--- a/src/components/puzzle.js
+++ b/src/components/puzzle.js
@@ -789,7 +789,7 @@ export class Puzzle {
 
     this.footerMessages.reset()
     this.headerMessages.reset()
-    this.state.setSolution([])
+    this.state.setSolution()
 
     this.layout = new Layout(layout)
     this.#requirements = new Requirements(requirements)

--- a/src/components/state.js
+++ b/src/components/state.js
@@ -205,7 +205,7 @@ export class State {
   }
 
   setSolution (tiles) {
-    this.#solution = tiles.map((tile) => tile.coordinates.offset.toString())
+    this.#solution = tiles?.map((tile) => tile.coordinates.offset.toString())
     this.updateCache()
   }
 

--- a/src/puzzles/001.json
+++ b/src/puzzles/001.json
@@ -2268,6 +2268,11 @@
             "type": "puzzle",
             "name": "unlocked",
             "unlocked": true
+          },
+          {
+            "type": "tile",
+            "name": "in-solution",
+            "inSolution": true
           }
         ]
       },
@@ -2419,7 +2424,7 @@
       }
     ]
   },
-  "version": 0,
+  "version": 1,
   "requirements": [
     {
       "type": "connections",

--- a/test/editor/config.js
+++ b/test/editor/config.js
@@ -3,7 +3,7 @@ import { PuzzleFixture, removeKeys } from '../fixtures.js'
 import assert from 'assert'
 
 describe('Editor', function () {
-  const puzzle = new PuzzleFixture('config', 'edit')
+  const puzzle = new PuzzleFixture('config', { mode: 'edit' })
 
   after(puzzle.after)
   before(puzzle.before)

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -31,10 +31,13 @@ export class PuzzleFixture {
   driver
   elements = {}
 
-  constructor (id, mode = 'play', unlock = true) {
+  static DefaultOptions = Object.freeze({ mode: 'play', unlock: true })
+
+  constructor (id, options) {
+    options = Object.assign({}, PuzzleFixture.DefaultOptions, options)
     this.after = this.after.bind(this)
     this.before = this.before.bind(this)
-    this.url = `${PuzzleFixture.baseUrl}/?${mode}${unlock ? '&unlock' : ''}#/${id}`
+    this.url = `${PuzzleFixture.baseUrl}/?${options.mode}${options.unlock ? '&unlock' : ''}#/${id}`
   }
 
   async after () {
@@ -107,6 +110,10 @@ export class PuzzleFixture {
 
   async getModifier (name) {
     return this.driver.wait(until.elementLocated(By.css(`.modifier-${name.toLowerCase()}:not(.disabled)`)))
+  }
+
+  async getShareUrl () {
+    return await this.driver.executeScript('return game.puzzle.getShareUrl()')
   }
 
   async isLoaded () {

--- a/test/puzzles/001.js
+++ b/test/puzzles/001.js
@@ -83,6 +83,18 @@ const solutions = {
     { type: 'tile-select', tile: '-1,-1' },
     { type: 'modifier-invoke', modifier: 'swap' },
     { type: 'tile-click', tile: '0,-1' }
+  ],
+  '007': [
+    { type: 'tile-select', tile: '1,-1' },
+    { type: 'modifier-invoke', modifier: 'move' },
+    { type: 'tile-click', tile: '0,-2' },
+    { type: 'tile-select', tile: '1,0' },
+    { type: 'modifier-invoke', modifier: 'move' },
+    { type: 'tile-click', tile: '0,2' },
+    { type: 'tile-select', tile: '0,0' },
+    { type: 'modifier-invoke', modifier: 'rotate' },
+    { type: 'modifier-invoke', modifier: 'move' },
+    { type: 'tile-click', tile: '0,1' }
   ]
 }
 
@@ -90,7 +102,7 @@ describe('Puzzle 001', function () {
   // This test needs more time
   this.timeout(60000)
 
-  const puzzle = new PuzzleFixture('001')
+  const puzzle = new PuzzleFixture('001', { unlock: false })
 
   after(puzzle.after)
   before(puzzle.before)
@@ -184,8 +196,14 @@ describe('Puzzle 001', function () {
         { type: 'modifier-invoke', modifier: 'rotate', options: { times: 2 } },
         { type: 'modifier-invoke', modifier: 'puzzle' },
         { type: 'wait', for: 'puzzle-loaded' }
+      ],
+      solutions['007'],
+      [
+        { type: 'continue' }
       ]
     ].flat())
+
+    console.log(await puzzle.getShareUrl())
 
     assert(await puzzle.isSolved())
   })


### PR DESCRIPTION
Adds the `tile-inSolution` filter to puzzle 007. Also updates the logic for that filter to treat puzzles with empty solutions (`[]`) as including all tiles (rather than none). The in-state solution property is now also properly reset prior to a puzzle being loaded (it is now `undefined` instead of `[]`).

This also adds test coverage through solving puzzle 007.